### PR TITLE
Doc test and dependency maintenance

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -33,9 +33,9 @@ dependencies = [
 
 [[package]]
 name = "autocfg"
-version = "1.0.1"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cdb031dd78e28731d87d56cc8ffef4a8f36ca26c38fe2de700543e627f8a464a"
+checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
 name = "bitflags"
@@ -68,8 +68,8 @@ dependencies = [
  "goblin",
  "ignore",
  "memmap",
- "scroll 0.11.0",
- "scroll_derive 0.11.0",
+ "scroll",
+ "scroll_derive",
  "serde",
  "serde_derive",
  "serde_json",
@@ -78,18 +78,27 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "3.0.14"
+version = "3.1.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b63edc3f163b3c71ec8aa23f9bd6070f77edbf3d1d198b164afa90ff00e4ec62"
+checksum = "d2dbdf4bdacb33466e854ce889eee8dfd5729abf7ccd7664d0a2d60cd384440b"
 dependencies = [
  "atty",
  "bitflags",
+ "clap_lex",
  "indexmap",
  "lazy_static",
- "os_str_bytes",
  "strsim",
  "termcolor",
  "textwrap",
+]
+
+[[package]]
+name = "clap_lex"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a37c35f1112dad5e6e0b1adaff798507497a18fceeb30cceb3bae7d1427b9213"
+dependencies = [
+ "os_str_bytes",
 ]
 
 [[package]]
@@ -118,15 +127,15 @@ dependencies = [
 
 [[package]]
 name = "core-foundation-sys"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea221b5284a47e40033bf9b66f35f984ec0ea2931eb03505246cd27a963f981b"
+checksum = "5827cebf4670468b8772dd191856768aedcb1b0278a04f989f7766351917b9dc"
 
 [[package]]
 name = "crossbeam-channel"
-version = "0.5.1"
+version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06ed27e177f16d65f0f0c22a213e17c696ace5dd64b14258b52f9417ccb52db4"
+checksum = "5aaa7bd5fb665c6864b5f963dd9097905c54125909c7aa94c9e18507cdbe6c53"
 dependencies = [
  "cfg-if",
  "crossbeam-utils",
@@ -145,10 +154,11 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.5"
+version = "0.9.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ec02e091aa634e2c3ada4a392989e7c3116673ef0ac5b72232439094d73b7fd"
+checksum = "1145cf131a2c6ba0615079ab6a638f7e1973ac9c2634fcbeaaad6114246efe8c"
 dependencies = [
+ "autocfg",
  "cfg-if",
  "crossbeam-utils",
  "lazy_static",
@@ -158,9 +168,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.5"
+version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d82cfc11ce7f2c3faef78d8a684447b40d503d9681acebed6cb728d45940c4db"
+checksum = "0bf124c720b7686e3c2663cf54062ab0f68a88af2fb6a030e87e30bf721fcb38"
 dependencies = [
  "cfg-if",
  "lazy_static",
@@ -193,13 +203,13 @@ dependencies = [
 
 [[package]]
 name = "goblin"
-version = "0.4.3"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32401e89c6446dcd28185931a01b1093726d0356820ac744023e6850689bf926"
+checksum = "c955ab4e0ad8c843ea653a3d143048b87490d9be56bd7132a435c2407846ac8f"
 dependencies = [
  "log",
  "plain",
- "scroll 0.10.2",
+ "scroll",
 ]
 
 [[package]]
@@ -237,9 +247,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "1.8.0"
+version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "282a6247722caba404c065016bbfa522806e51714c34f5dfc3e4a3a46fcb4223"
+checksum = "e6012d540c5baa3589337a98ce73408de9b5a25ec9fc2c6fd6be8f0d39e0ca5a"
 dependencies = [
  "autocfg",
  "hashbrown",
@@ -247,9 +257,9 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "1.0.1"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1aab8fc367588b89dcee83ab0fd66b72b50b72fa1904d7095045ace2b0c81c35"
+checksum = "112c678d4050afce233f4f2852bb2eb519230b3cf12f33585275537d7e41578d"
 
 [[package]]
 name = "lazy_static"
@@ -259,24 +269,24 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.116"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "565dbd88872dbe4cc8a46e527f26483c1d1f7afa6b884a3bd6cd893d4f98da74"
+checksum = "349d5a591cd28b49e1d1037471617a32ddcda5731b99419008085f72d5a53836"
 
 [[package]]
 name = "log"
-version = "0.4.14"
+version = "0.4.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51b9bbe6c47d51fc3e1a9b945965946b4c44142ab8792c50835a980d362c2710"
+checksum = "abb12e687cfb44aa40f41fc3978ef76448f9b6038cad6aef4259d3c095a2382e"
 dependencies = [
  "cfg-if",
 ]
 
 [[package]]
 name = "memchr"
-version = "2.4.1"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "308cc39be01b73d0d18f82a0e7b2a3df85245f84af96fdddc5d202d27e47b86a"
+checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
 
 [[package]]
 name = "memmap"
@@ -290,27 +300,27 @@ dependencies = [
 
 [[package]]
 name = "memoffset"
-version = "0.6.4"
+version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59accc507f1338036a0477ef61afdae33cde60840f4dfe481319ce3ad116ddf9"
+checksum = "5aa361d4faea93603064a027415f07bd8e1d5c88c9fbf68bf56a285428fd79ce"
 dependencies = [
  "autocfg",
 ]
 
 [[package]]
 name = "ntapi"
-version = "0.3.6"
+version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f6bb902e437b6d86e03cce10a7e2af662292c5dfef23b65899ea3ac9354ad44"
+checksum = "c28774a7fd2fbb4f0babd8237ce554b73af68021b5f695a3cebd6c59bac0980f"
 dependencies = [
  "winapi",
 ]
 
 [[package]]
 name = "num_cpus"
-version = "1.13.0"
+version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05499f3756671c15885fee9034446956fff3f243d6077b91e5767df161f766b3"
+checksum = "19e64526ebdee182341572e50e9ad03965aa510cd94427a4549448f285e957a1"
 dependencies = [
  "hermit-abi",
  "libc",
@@ -318,18 +328,15 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.8.0"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "692fcb63b64b1758029e0a96ee63e049ce8c5948587f2f7208df04625e5f6b56"
+checksum = "7709cef83f0c1f58f666e746a08b21e0085f7440fa6a29cc194d68aac97a4225"
 
 [[package]]
 name = "os_str_bytes"
-version = "6.0.0"
+version = "6.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e22443d1643a904602595ba1cd8f7d896afe56d26712531c5ff73a15b2fbf64"
-dependencies = [
- "memchr",
-]
+checksum = "21326818e99cfe6ce1e524c2a805c189a99b5ae555a35d19f9a284b427d86afa"
 
 [[package]]
 name = "plain"
@@ -339,27 +346,27 @@ checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.29"
+version = "1.0.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9f5105d4fdaab20335ca9565e106a5d9b82b6219b5ba735731124ac6711d23d"
+checksum = "c54b25569025b7fc9651de43004ae593a75ad88543b17178aa5e1b9c4f15f56f"
 dependencies = [
- "unicode-xid",
+ "unicode-ident",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.10"
+version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38bc8cc6a5f2e3655e0899c1b848643b2562f853f114bfec7be120678e3ace05"
+checksum = "a1feb54ed693b93a84e14094943b84b7c4eae204c512b7ccb95ab0c66d278ad1"
 dependencies = [
  "proc-macro2",
 ]
 
 [[package]]
 name = "rayon"
-version = "1.5.1"
+version = "1.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c06aca804d41dbc8ba42dfd964f0d01334eceb64314b9ecf7c5fad5188a06d90"
+checksum = "bd99e5772ead8baa5215278c9b15bf92087709e9c1b2d1f97cdb5a183c933a7d"
 dependencies = [
  "autocfg",
  "crossbeam-deque",
@@ -369,22 +376,21 @@ dependencies = [
 
 [[package]]
 name = "rayon-core"
-version = "1.9.1"
+version = "1.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d78120e2c850279833f1dd3582f730c4ab53ed95aeaaaa862a2a5c71b1656d8e"
+checksum = "258bcdb5ac6dad48491bb2992db6b7cf74878b0384908af124823d118c99683f"
 dependencies = [
  "crossbeam-channel",
  "crossbeam-deque",
  "crossbeam-utils",
- "lazy_static",
  "num_cpus",
 ]
 
 [[package]]
 name = "regex"
-version = "1.5.4"
+version = "1.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d07a8629359eb56f1e2fb1652bb04212c072a87ba68546a04065d525673ac461"
+checksum = "d83f127d94bdbcda4c8cc2e50f6f84f4b611f69c902699ca385a39c3a75f9ff1"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -393,15 +399,15 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.6.25"
+version = "0.6.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f497285884f3fcff424ffc933e56d7cbca511def0c9831a7f9b5f6153e3cc89b"
+checksum = "49b3de9ec5dc0a3417da371aab17d729997c15010e7fd24ff707773a33bddb64"
 
 [[package]]
 name = "ryu"
-version = "1.0.5"
+version = "1.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71d301d4193d031abdd79ff7e3dd721168a9572ef3fe51a1517aba235bd8f86e"
+checksum = "f3f6f92acf49d1b98f7a81226834412ada05458b7364277387724a237f062695"
 
 [[package]]
 name = "same-file"
@@ -420,28 +426,11 @@ checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
 
 [[package]]
 name = "scroll"
-version = "0.10.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fda28d4b4830b807a8b43f7b0e6b5df875311b3e7621d84577188c175b6ec1ec"
-dependencies = [
- "scroll_derive 0.10.5",
-]
-
-[[package]]
-name = "scroll"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04c565b551bafbef4157586fa379538366e4385d42082f255bfd96e4fe8519da"
-
-[[package]]
-name = "scroll_derive"
-version = "0.10.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aaaae8f38bb311444cfb7f1979af0bc9240d95795f75f9ceddf6a59b79ceffa0"
 dependencies = [
- "proc-macro2",
- "quote",
- "syn",
+ "scroll_derive",
 ]
 
 [[package]]
@@ -457,18 +446,18 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.136"
+version = "1.0.137"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce31e24b01e1e524df96f1c2fdd054405f8d7376249a5110886fb4b658484789"
+checksum = "61ea8d54c77f8315140a05f4c7237403bf38b72704d031543aa1d16abbf517d1"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.136"
+version = "1.0.137"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08597e7152fcd306f41838ed3e37be9eaeed2b61c42e2117266a554fab4662f9"
+checksum = "1f26faba0c3959972377d3b2d306ee9f71faee9714294e41bb777f83f88578be"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -477,9 +466,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.78"
+version = "1.0.81"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d23c1ba4cf0efd44be32017709280b32d1cea5c3f1275c3b6d9e8bc54f758085"
+checksum = "9b7ce2b32a1aed03c558dc61a5cd328f15aff2dbc17daad8fb8af04d2100e15c"
 dependencies = [
  "itoa",
  "ryu",
@@ -494,20 +483,20 @@ checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
 name = "syn"
-version = "1.0.80"
+version = "1.0.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d010a1623fbd906d51d650a9916aaefc05ffa0e4053ff7fe601167f3e715d194"
+checksum = "fbaf6116ab8924f39d52792136fb74fd60a80194cf1b1c6ffa6453eef1c3f942"
 dependencies = [
  "proc-macro2",
  "quote",
- "unicode-xid",
+ "unicode-ident",
 ]
 
 [[package]]
 name = "sysinfo"
-version = "0.23.0"
+version = "0.23.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e757000a4bed2b1be9be65a3f418b9696adf30bb419214c73997422de73a591"
+checksum = "3977ec2e0520829be45c8a2df70db2bf364714d8a748316a10c3c35d4d2b01c9"
 dependencies = [
  "cfg-if",
  "core-foundation-sys",
@@ -520,33 +509,33 @@ dependencies = [
 
 [[package]]
 name = "termcolor"
-version = "1.1.2"
+version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2dfed899f0eb03f32ee8c6a0aabdb8a7949659e3466561fc0adf54e26d88c5f4"
+checksum = "bab24d30b911b2376f3a13cc2cd443142f0c81dda04c118693e35b3835757755"
 dependencies = [
  "winapi-util",
 ]
 
 [[package]]
 name = "textwrap"
-version = "0.14.2"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0066c8d12af8b5acd21e00547c3797fde4e8677254a7ee429176ccebbe93dd80"
+checksum = "b1141d4d61095b28419e22cb0bbf02755f5e54e0526f97f1e3d1d160e60885fb"
 
 [[package]]
 name = "thread_local"
-version = "1.1.3"
+version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8018d24e04c95ac8790716a5987d0fec4f8b27249ffa0f7d33f1369bdfb88cbd"
+checksum = "5516c27b78311c50bf42c071425c560ac799b11c30b31f87e3081965fe5e0180"
 dependencies = [
  "once_cell",
 ]
 
 [[package]]
-name = "unicode-xid"
-version = "0.2.2"
+name = "unicode-ident"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ccb82d61f80a663efe1f787a51b16b5a51e3314d6ac365b08639f52387b33f3"
+checksum = "d22af068fba1eb5edcb4aea19d382b2a3deb4c8f9d475c589b6ada9e0fd493ee"
 
 [[package]]
 name = "walkdir"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,18 +25,18 @@ opt-level = 'z'     # Optimize for size
 panic = 'abort'     # Abort on panic
 
 [dependencies]
-clap = { version = "3.0.14", features = ["cargo"] }
+clap = { version = "3.1.18", features = ["cargo"] }
 colored = { version = "2.0.0", optional = true }
 colored_json = { version = "2.1.0", optional = true }
-goblin = "0.4.3"
+goblin = "0.5.1"
 ignore = "0.4.18"
 memmap = "0.7.0"
 scroll = "0.11.0"
 scroll_derive = "0.11.0"
-serde = { version = "1.0.136", features = ["derive"] }
-serde_derive = "1.0.136"
-serde_json = "1.0.78"
-sysinfo = "0.23.0"
+serde = { version = "1.0.137", features = ["derive"] }
+serde_derive = "1.0.137"
+serde_json = "1.0.81"
+sysinfo = "0.23.13"
 
 [lib]
 name = "checksec"

--- a/src/elf.rs
+++ b/src/elf.rs
@@ -94,11 +94,9 @@ impl fmt::Display for PIE {
 /// use std::fs;
 ///
 /// pub fn print_results(binary: &String) {
-///     if let Ok(fp) = fs::File::open(&binary) {
-///         if let Ok(buf) = fs::read(fp) {
-///             if let Ok(elf) = Elf::parse(&buf) {
-///                 println!("{:#?}", ElfCheckSecResults::parse(&elf));
-///             }
+///     if let Ok(buf) = fs::read(binary) {
+///         if let Ok(elf) = Elf::parse(&buf) {
+///             println!("{:#?}", CheckSecResults::parse(&elf));
 ///         }
 ///     }
 /// }
@@ -207,11 +205,9 @@ impl fmt::Display for CheckSecResults {
 /// use std::fs;
 ///
 /// pub fn print_results(binary: &String) {
-///     if let Ok(fp) = fs::File::open(&binary) {
-///         if let Ok(buf) = fs::read(fp) {
-///             if let Ok(elf) = Elf::parse(&buf) {
-///                 println!("Canary: {}", elf.has_canary());
-///             }
+///     if let Ok(buf) = fs::read(binary) {
+///         if let Ok(elf) = Elf::parse(&buf) {
+///             println!("Canary: {}", elf.has_canary());
 ///         }
 ///     }
 /// }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,14 +12,14 @@
 //! [`goblin::Object`](https://docs.rs/goblin/latest/goblin/enum.Object.html)
 //! object to the parse method.
 //!
-//! * [`checksec::elf::ElfCheckSecResults`](./elf/struct.ElfCheckSecResults.html)
-//! * [`checksec::macho::MachOCheckSecResults`](./macho/struct.MachOCheckSecResults.html)
-//! * [`checksec::pe::PECheckSecResults`](./pe/struct.PECheckSecResults.html)
+//! * [`checksec::elf::CheckSecResults`](crate::elf::CheckSecResults)
+//! * [`checksec::macho::CheckSecResults`](crate::macho::CheckSecResults)
+//! * [`checksec::pe::CheckSecResults`](crate::pe::CheckSecResults)
 //!
 //! ```rust
-//! use checksec::elf::ElfCheckSecResults;
-//! use checksec::macho::MachOCheckSecResults;
-//! use checksec::pe::PECheckSecResults;
+//! use checksec::elf::CheckSecResults as ElfCheckSecResults;
+//! use checksec::macho::CheckSecResults as MachOCheckSecResults;
+//! use checksec::pe::CheckSecResults as PECheckSecResults;
 //! ```
 //!
 //! **Traits**
@@ -28,14 +28,14 @@
 //! have direct access to the security property check functions for a given
 //! binary executable format.
 //!
-//! * [`checksec::elf::ElfProperties`](./elf/trait.ElfProperties.html)
-//! * [`checksec::macho::MachOProperties`](./macho/trait.MachOProperties.html)
-//! * [`checksec::pe::PEProperties`](./pe/trait.PEProperties.html)
+//! * [`checksec::elf::Properties`](crate::elf::Properties)
+//! * [`checksec::macho::MachOProperties`](crate::macho::MachOProperties)
+//! * [`checksec::pe::Properties`](crate::pe::Properties)
 //!
 //! ```rust
-//! use checksec::elf::ElfProperties;
-//! use checksec::macho::MachOProperties;
-//! use checksec::pe::PEProperties;
+//! use checksec::elf::Properties as ElfProperties;
+//! use checksec::macho::MachOProperties as MachOProperties;
+//! use checksec::pe::Properties as PEProperties;
 //! ```
 //!
 //! Refer to the generated docs or the examples directory

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -34,7 +34,7 @@
 //!
 //! ```rust
 //! use checksec::elf::Properties as ElfProperties;
-//! use checksec::macho::Properties as Properties;
+//! use checksec::macho::Properties as MachOProperties;
 //! use checksec::pe::Properties as PEProperties;
 //! ```
 //!

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,12 +29,12 @@
 //! binary executable format.
 //!
 //! * [`checksec::elf::Properties`](crate::elf::Properties)
-//! * [`checksec::macho::MachOProperties`](crate::macho::MachOProperties)
+//! * [`checksec::macho::Properties`](crate::macho::Properties)
 //! * [`checksec::pe::Properties`](crate::pe::Properties)
 //!
 //! ```rust
 //! use checksec::elf::Properties as ElfProperties;
-//! use checksec::macho::MachOProperties as MachOProperties;
+//! use checksec::macho::Properties as Properties;
 //! use checksec::pe::Properties as PEProperties;
 //! ```
 //!

--- a/src/macho.rs
+++ b/src/macho.rs
@@ -139,7 +139,7 @@ impl fmt::Display for CheckSecResults {
 /// **Example**
 ///
 /// ```rust
-/// use checksec::macho::MachOProperties;
+/// use checksec::macho::Properties;
 /// use goblin::mach::MachO;
 /// use std::fs;
 ///
@@ -151,7 +151,7 @@ impl fmt::Display for CheckSecResults {
 ///     }
 /// }
 /// ```
-pub trait MachOProperties {
+pub trait Properties {
     /// check import names for `_objc_release`
     fn has_arc(&self) -> bool;
     /// check import names for `___stack_chk_fail` or `___stack_chk_guard`
@@ -177,7 +177,7 @@ pub trait MachOProperties {
     /// check for `RPath` in load commands
     fn has_rpath(&self) -> bool;
 }
-impl MachOProperties for MachO<'_> {
+impl Properties for MachO<'_> {
     fn has_arc(&self) -> bool {
         if let Ok(imports) = self.imports() {
             for import in &imports {

--- a/src/macho.rs
+++ b/src/macho.rs
@@ -24,11 +24,9 @@ const MH_NO_HEAP_EXECUTION: u32 = 0x0100_0000;
 /// use std::fs;
 ///
 /// pub fn print_results(binary: &String) {
-///     if let Ok(fp) = fs::File::open(&binary) {
-///         if let Ok(buf) = fs::read(fp) {
-///             if let Ok(macho) = MachO::parse(&buf) {
-///                 println!("{:#?}", CheckSecResults::parse(&macho));
-///             }
+///     if let Ok(buf) = fs::read(binary) {
+///         if let Ok(macho) = MachO::parse(&buf, 0) {
+///             println!("{:#?}", CheckSecResults::parse(&macho));
 ///         }
 ///     }
 /// }
@@ -146,11 +144,9 @@ impl fmt::Display for CheckSecResults {
 /// use std::fs;
 ///
 /// pub fn print_results(binary: &String) {
-///     if let Ok(fp) = fs::File::open(&binary) {
-///         if let Ok(buf) = fs::read(fp) {
-///             if let Ok(macho) = MachO::parse(&buf) {
-///                 println!("arc: {}", macho.has_arc());
-///             }
+///     if let Ok(buf) = fs::read(binary) {
+///         if let Ok(macho) = MachO::parse(&buf, 0) {
+///             println!("arc: {}", macho.has_arc());
 ///         }
 ///     }
 /// }

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,7 +6,7 @@ extern crate serde_json;
 extern crate sysinfo;
 
 use clap::{
-    crate_authors, crate_description, crate_version, App, AppSettings, Arg,
+    crate_authors, crate_description, crate_version, Command, Arg,
 };
 use goblin::error::Error;
 #[cfg(feature = "macho")]
@@ -160,11 +160,11 @@ fn walk(basepath: &Path, json: bool, pretty: bool) {
 }
 #[allow(clippy::too_many_lines, clippy::cognitive_complexity)]
 fn main() {
-    let args = App::new("checksec")
+    let args = Command::new("checksec")
         .about(crate_description!())
         .author(crate_authors!())
         .version(crate_version!())
-        .setting(AppSettings::ArgRequiredElseHelp)
+        .arg_required_else_help(true)
         .arg(
             Arg::new("file")
                 .short('f')

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,9 +5,7 @@ extern crate ignore;
 extern crate serde_json;
 extern crate sysinfo;
 
-use clap::{
-    crate_authors, crate_description, crate_version, Command, Arg,
-};
+use clap::{crate_authors, crate_description, crate_version, Arg, Command};
 use goblin::error::Error;
 #[cfg(feature = "macho")]
 use goblin::mach::Mach;

--- a/src/pe.rs
+++ b/src/pe.rs
@@ -275,8 +275,8 @@ impl fmt::Display for ASLR {
 /// **Example**
 ///
 /// ```rust
-/// use checksec::pe::Properties;
-/// use goblin::pe::PE;
+/// use checksec::pe::{Properties, CheckSecResults};
+/// use goblin::{pe::PE, Object};
 /// use memmap::Mmap;
 /// use std::fs;
 ///

--- a/src/pe.rs
+++ b/src/pe.rs
@@ -9,7 +9,6 @@ use goblin::pe::{
 };
 use memmap::Mmap;
 use scroll::Pread;
-use scroll_derive::Pread;
 use serde::{Deserialize, Serialize};
 use std::fmt;
 use std::mem::size_of;


### PR DESCRIPTION
This PR addresses #12 and misc/minor related:

- Fix failing doc tests
- Rename `MachOProperties` to `Properties` for consistency with ELF and PE
- Update all dependencies to latest currently available on crates.io
- Remove depreciated `clap` functions

#12 is currently a blocker to releasing an updated version of `xgadget` on crates.io ([PR in progress](https://github.com/entropic-security/xgadget/pull/11)), so if these minor updates could be pushed to crates.io ASAP I'd really appreciate it!

Fully understand that this is a best-effort open-source project and am happy to work on this PR or other fixes to keep this crate going. I rely on it and I'm sure others do too :+1: 