### PR TITLE
Misc stuff

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -67,3 +67,6 @@ jobs:
         cargo clippy --all -- -D clippy::all -D clippy::pedantic
     - run: cargo build
     - run: cargo build --all-targets
+    - run: cargo build --no-default-features --features elf
+    - run: cargo build --no-default-features --features pe
+    - run: cargo build --no-default-features --features macho

--- a/src/binary.rs
+++ b/src/binary.rs
@@ -1,6 +1,7 @@
 #[cfg(feature = "color")]
 use colored::Colorize;
 use serde::{Deserialize, Serialize};
+use std::path::PathBuf;
 use std::{fmt, usize};
 
 #[cfg(feature = "elf")]
@@ -89,7 +90,7 @@ impl fmt::Display for BinSpecificProperties {
 #[derive(Debug, Deserialize, Serialize)]
 pub struct Binary {
     pub binarytype: BinType,
-    pub file: String,
+    pub file: PathBuf,
     pub properties: BinSpecificProperties,
 }
 #[cfg(not(feature = "color"))]
@@ -98,7 +99,9 @@ impl fmt::Display for Binary {
         write!(
             f,
             "{}: | {} | File: {}",
-            self.binarytype, self.properties, self.file
+            self.binarytype,
+            self.properties,
+            self.file.display()
         )
     }
 }
@@ -111,14 +114,14 @@ impl fmt::Display for Binary {
             self.binarytype,
             self.properties,
             "File:".bold().underline(),
-            self.file.bright_blue()
+            self.file.display().to_string().bright_blue()
         )
     }
 }
 impl Binary {
     pub const fn new(
         binarytype: BinType,
-        file: String,
+        file: PathBuf,
         properties: BinSpecificProperties,
     ) -> Self {
         Self { binarytype, file, properties }

--- a/src/elf.rs
+++ b/src/elf.rs
@@ -256,17 +256,18 @@ impl Properties for Elf<'_> {
         }
         false
     }
+    #[allow(clippy::case_sensitive_file_extension_comparisons)]
     fn has_clang_cfi(&self) -> bool {
         for sym in &self.syms {
             if let Some(name) = self.strtab.get_at(sym.st_name) {
-                if name.contains(".cfi") {
+                if name.ends_with(".cfi") {
                     return true;
                 }
             }
         }
         for sym in &self.dynsyms {
             if let Some(name) = self.dynstrtab.get_at(sym.st_name) {
-                if name.contains(".cfi") || name.contains("_cfi") {
+                if name.ends_with(".cfi") || name == "__cfi_init" {
                     return true;
                 }
             }

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,7 +5,9 @@ extern crate ignore;
 extern crate serde_json;
 extern crate sysinfo;
 
-use clap::{crate_authors, crate_description, crate_version, Arg, Command};
+use clap::{
+    crate_authors, crate_description, crate_version, Arg, ArgGroup, Command,
+};
 use goblin::error::Error;
 #[cfg(feature = "macho")]
 use goblin::mach::Mach;
@@ -227,11 +229,7 @@ fn main() {
                 .long("directory")
                 .value_name("DIRECTORY")
                 .help("Target directory")
-                .takes_value(true)
-                .conflicts_with("file")
-                .conflicts_with("pid")
-                .conflicts_with("process")
-                .conflicts_with("process-all"),
+                .takes_value(true),
         )
         .arg(
             Arg::new("file")
@@ -239,11 +237,7 @@ fn main() {
                 .long("file")
                 .value_name("FILE")
                 .help("Target file")
-                .takes_value(true)
-                .conflicts_with("directory")
-                .conflicts_with("pid")
-                .conflicts_with("process")
-                .conflicts_with("process-all"),
+                .takes_value(true),
         )
         .arg(
             Arg::new("json")
@@ -256,8 +250,10 @@ fn main() {
                 .short('m')
                 .long("maps")
                 .help("Include process memory maps (Linux only)")
+                .requires("pid")
                 .requires("process")
-                .requires("process-all"),
+                .requires("process-all")
+                .conflicts_with_all(&["directory", "file"]),
         )
         .arg(
             Arg::new("no-color")
@@ -272,11 +268,7 @@ fn main() {
                     "Process ID of running process to check\n\
                     (comma separated for multiple PIDs)",
                 )
-                .takes_value(true)
-                .conflicts_with("directory")
-                .conflicts_with("file")
-                .conflicts_with("process")
-                .conflicts_with("process-all"),
+                .takes_value(true),
         )
         .arg(
             Arg::new("pretty")
@@ -290,21 +282,18 @@ fn main() {
                 .long("process")
                 .value_name("NAME")
                 .help("Name of running process to check")
-                .takes_value(true)
-                .conflicts_with("directory")
-                .conflicts_with("file")
-                .conflicts_with("pid")
-                .conflicts_with("process-all"),
+                .takes_value(true),
         )
         .arg(
             Arg::new("process-all")
                 .short('P')
                 .long("process-all")
-                .help("Check all running processes")
-                .conflicts_with("directory")
-                .conflicts_with("file")
-                .conflicts_with("pid")
-                .conflicts_with("process"),
+                .help("Check all running processes"),
+        )
+        .group(
+            ArgGroup::new("operation")
+                .args(&["directory", "file", "pid", "process", "process-all"])
+                .required(true),
         )
         .get_matches();
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -182,11 +182,11 @@ fn parse(file: &Path) -> Result<Vec<Binary>, Error> {
                                     } else {
                                         BinType::MachO32
                                     };
-                                    fat_bins.append(&mut vec![Binary::new(
+                                    fat_bins.push(Binary::new(
                                         bin_type,
                                         file.display().to_string(),
                                         BinSpecificProperties::MachO(results),
-                                    )]);
+                                    ));
                                 }
                             }
                         }
@@ -326,10 +326,7 @@ fn main() {
         let mut procs: Vec<Process> = Vec::new();
         for (pid, proc_entry) in system.processes() {
             if let Ok(results) = parse(proc_entry.exe()) {
-                procs.append(&mut vec![Process::new(
-                    pid.as_u32() as usize,
-                    results,
-                )]);
+                procs.push(Process::new(pid.as_u32() as usize, results));
             }
         }
         print_process_results(&Processes::new(procs), &settings);
@@ -370,10 +367,8 @@ fn main() {
 
             match parse(process.exe()) {
                 Ok(results) => {
-                    procs.append(&mut vec![Process::new(
-                        procid.as_u32() as usize,
-                        results,
-                    )]);
+                    procs
+                        .push(Process::new(procid.as_u32() as usize, results));
                 }
                 Err(msg) => {
                     eprintln!(
@@ -396,10 +391,10 @@ fn main() {
         let mut procs: Vec<Process> = Vec::new();
         for proc_entry in sysprocs {
             if let Ok(results) = parse(proc_entry.exe()) {
-                procs.append(&mut vec![Process::new(
+                procs.push(Process::new(
                     proc_entry.pid().as_u32() as usize,
                     results,
-                )]);
+                ));
             }
         }
         if procs.is_empty() {

--- a/src/main.rs
+++ b/src/main.rs
@@ -222,18 +222,6 @@ fn main() {
         .version(crate_version!())
         .arg_required_else_help(true)
         .arg(
-            Arg::new("file")
-                .short('f')
-                .long("file")
-                .value_name("FILE")
-                .help("Target file")
-                .takes_value(true)
-                .conflicts_with("directory")
-                .conflicts_with("pid")
-                .conflicts_with("process")
-                .conflicts_with("process-all"),
-        )
-        .arg(
             Arg::new("directory")
                 .short('d')
                 .long("directory")
@@ -241,6 +229,18 @@ fn main() {
                 .help("Target directory")
                 .takes_value(true)
                 .conflicts_with("file")
+                .conflicts_with("pid")
+                .conflicts_with("process")
+                .conflicts_with("process-all"),
+        )
+        .arg(
+            Arg::new("file")
+                .short('f')
+                .long("file")
+                .value_name("FILE")
+                .help("Target file")
+                .takes_value(true)
+                .conflicts_with("directory")
                 .conflicts_with("pid")
                 .conflicts_with("process")
                 .conflicts_with("process-all"),
@@ -255,7 +255,7 @@ fn main() {
             Arg::new("maps")
                 .short('m')
                 .long("maps")
-                .help("Include process memory maps (linux only)")
+                .help("Include process memory maps (Linux only)")
                 .requires("process")
                 .requires("process-all"),
         )
@@ -263,6 +263,20 @@ fn main() {
             Arg::new("no-color")
                 .long("no-color")
                 .help("Disables color output"),
+        )
+        .arg(
+            Arg::new("pid")
+                .long("pid")
+                .value_name("PID")
+                .help(
+                    "Process ID of running process to check\n\
+                    (comma separated for multiple PIDs)",
+                )
+                .takes_value(true)
+                .conflicts_with("directory")
+                .conflicts_with("file")
+                .conflicts_with("process")
+                .conflicts_with("process-all"),
         )
         .arg(
             Arg::new("pretty")
@@ -280,20 +294,6 @@ fn main() {
                 .conflicts_with("directory")
                 .conflicts_with("file")
                 .conflicts_with("pid")
-                .conflicts_with("process-all"),
-        )
-        .arg(
-            Arg::new("pid")
-                .long("pid")
-                .value_name("PID")
-                .help(
-                    "Process ID of running process to check\n\
-                    (comma separated for multiple PIDs)",
-                )
-                .takes_value(true)
-                .conflicts_with("directory")
-                .conflicts_with("file")
-                .conflicts_with("process")
                 .conflicts_with("process-all"),
         )
         .arg(

--- a/src/main.rs
+++ b/src/main.rs
@@ -164,7 +164,7 @@ fn parse(file: &Path) -> Result<Vec<Binary>, ParseError> {
                 if elf.is_64 { BinType::Elf64 } else { BinType::Elf32 };
             Ok(vec![Binary::new(
                 bin_type,
-                file.display().to_string(),
+                file.to_path_buf(),
                 BinSpecificProperties::Elf(results),
             )])
         }
@@ -175,7 +175,7 @@ fn parse(file: &Path) -> Result<Vec<Binary>, ParseError> {
                 if pe.is_64 { BinType::PE64 } else { BinType::PE32 };
             Ok(vec![Binary::new(
                 bin_type,
-                file.display().to_string(),
+                file.to_path_buf(),
                 BinSpecificProperties::PE(results),
             )])
         }
@@ -190,7 +190,7 @@ fn parse(file: &Path) -> Result<Vec<Binary>, ParseError> {
                 };
                 Ok(vec![Binary::new(
                     bin_type,
-                    file.display().to_string(),
+                    file.to_path_buf(),
                     BinSpecificProperties::MachO(results),
                 )])
             }
@@ -207,7 +207,7 @@ fn parse(file: &Path) -> Result<Vec<Binary>, ParseError> {
                         };
                         fat_bins.push(Binary::new(
                             bin_type,
-                            file.display().to_string(),
+                            file.to_path_buf(),
                             BinSpecificProperties::MachO(results),
                         ));
                     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -328,13 +328,15 @@ fn main() {
     let procname = args.value_of("process");
     let procall = args.is_present("process-all");
 
-    let mut format = output::Format::Text;
-    if args.is_present("json") {
-        format = output::Format::Json;
+    let format = if args.is_present("json") {
         if args.is_present("pretty") {
-            format = output::Format::JsonPretty;
+            output::Format::JsonPretty
+        } else {
+            output::Format::Json
         }
-    }
+    } else {
+        output::Format::Text
+    };
 
     let settings = output::Settings::set(
         #[cfg(feature = "color")]

--- a/src/proc.rs
+++ b/src/proc.rs
@@ -360,7 +360,10 @@ impl Process {
         match Process::parse_maps(pid) {
             Ok(maps) => Self { pid, binary, maps: Some(maps) },
             Err(e) => {
-                eprintln!("parse_maps Error: {}", e);
+                eprintln!(
+                    "Failed to parse maps for process with ID {}: {}",
+                    pid, e
+                );
                 Self { pid, binary, maps: None }
             }
         }


### PR DESCRIPTION
* Order argument definitions
Order the command line arguments by name to increase maintainability for
future additions.

* Use ArgGroup to simplify conflicts
Also now `checksec -m --no-color` fails with help shown.

* Simplifications
Push single elements into a vector instead appending a temporary wrapper
vector.

* Improve output for unsupported file types
Print actual magic value on error.
Print type of object for not implemented ones.

* Store path in Binary as PathBuf
Retain the path property of the file member for future usage.

* Improve error message

* CI: build single feature configurations
Test builds with only one binary format enabled and color support
disabled.