### PR TITLE
Upgrade dependencies and move away from unmaintained crates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12,15 +12,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ansi_term"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d52a9bb7ec0cf484c551830a7ce27bd20d67eac647e1befb56b0be4ee39a55d2"
-dependencies = [
- "winapi",
-]
-
-[[package]]
 name = "atty"
 version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -67,7 +58,7 @@ dependencies = [
  "colored_json",
  "goblin",
  "ignore",
- "memmap",
+ "memmap2",
  "scroll",
  "scroll_derive",
  "serde",
@@ -79,25 +70,23 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "3.2.22"
+version = "4.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86447ad904c7fb335a790c9d7fe3d0d971dc523b8ccd1561a520de9a85302750"
+checksum = "7f78ad8e84aa8e8aa3e821857be40eb4b925ff232de430d4dd2ae6aa058cbd92"
 dependencies = [
  "atty",
  "bitflags",
  "clap_lex",
- "indexmap",
  "once_cell",
  "strsim",
  "termcolor",
- "textwrap",
 ]
 
 [[package]]
 name = "clap_lex"
-version = "0.2.4"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2850f2f5a82cbf437dd5af4d49848fbdfc27c157c3d010345776f952765261c5"
+checksum = "0d4198f73e42b4936b35b5bb248d81d2b595ecb170da0bac7655c54eedfa8da8"
 dependencies = [
  "os_str_bytes",
 ]
@@ -115,15 +104,14 @@ dependencies = [
 
 [[package]]
 name = "colored_json"
-version = "2.1.0"
+version = "3.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fd32eb54d016e203b7c2600e3a7802c75843a92e38ccc4869aefeca21771a64"
+checksum = "633215cdbb84194508d4c07c08d06e92ee9d489d54e68d17913d8d1bacfcfdeb"
 dependencies = [
- "ansi_term",
  "atty",
- "libc",
  "serde",
  "serde_json",
+ "yansi",
 ]
 
 [[package]]
@@ -212,12 +200,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "hashbrown"
-version = "0.12.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
-
-[[package]]
 name = "hermit-abi"
 version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -242,16 +224,6 @@ dependencies = [
  "thread_local",
  "walkdir",
  "winapi-util",
-]
-
-[[package]]
-name = "indexmap"
-version = "1.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10a35a97730320ffe8e2d410b5d3b69279b98d2c14bdb8b70ea89ecf7888d41e"
-dependencies = [
- "autocfg",
- "hashbrown",
 ]
 
 [[package]]
@@ -288,13 +260,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
 
 [[package]]
-name = "memmap"
-version = "0.7.0"
+name = "memmap2"
+version = "0.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6585fd95e7bb50d6cc31e20d4cf9afb4e2ba16c5846fc76793f11218da9c475b"
+checksum = "95af15f345b17af2efc8ead6080fb8bc376f8cec1b35277b935637595fe77498"
 dependencies = [
  "libc",
- "winapi",
 ]
 
 [[package]]
@@ -308,9 +279,9 @@ dependencies = [
 
 [[package]]
 name = "ntapi"
-version = "0.3.7"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c28774a7fd2fbb4f0babd8237ce554b73af68021b5f695a3cebd6c59bac0980f"
+checksum = "bc51db7b362b205941f71232e56c625156eb9a929f8cf74a428fd5bc094a4afc"
 dependencies = [
  "winapi",
 ]
@@ -493,9 +464,9 @@ dependencies = [
 
 [[package]]
 name = "sysinfo"
-version = "0.24.7"
+version = "0.26.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54cb4ebf3d49308b99e6e9dc95e989e2fdbdc210e4f67c39db0bb89ba927001c"
+checksum = "7890fff842b8db56f2033ebee8f6efe1921475c3830c115995552914fb967580"
 dependencies = [
  "cfg-if",
  "core-foundation-sys",
@@ -514,12 +485,6 @@ checksum = "bab24d30b911b2376f3a13cc2cd443142f0c81dda04c118693e35b3835757755"
 dependencies = [
  "winapi-util",
 ]
-
-[[package]]
-name = "textwrap"
-version = "0.15.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "949517c0cf1bf4ee812e2e07e08ab448e3ae0d23472aee8a06c985f0c8815b16"
 
 [[package]]
 name = "thread_local"
@@ -580,43 +545,63 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows"
-version = "0.38.0"
+version = "0.42.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c47017195a790490df51a3e27f669a7d4f285920d90d03ef970c5d886ef0af1"
+checksum = "0286ba339aa753e70765d521bb0242cc48e1194562bfa2a2ad7ac8a6de28f5d5"
 dependencies = [
+ "windows_aarch64_gnullvm",
  "windows_aarch64_msvc",
  "windows_i686_gnu",
  "windows_i686_msvc",
  "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
  "windows_x86_64_msvc",
 ]
 
 [[package]]
-name = "windows_aarch64_msvc"
-version = "0.38.0"
+name = "windows_aarch64_gnullvm"
+version = "0.42.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b12add87e2fb192fff3f4f7e4342b3694785d79f3a64e2c20d5ceb5ccbcfc3cd"
+checksum = "41d2aa71f6f0cbe00ae5167d90ef3cfe66527d6f613ca78ac8024c3ccab9a19e"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.42.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd0f252f5a35cac83d6311b2e795981f5ee6e67eb1f9a7f64eb4500fbc4dcdb4"
 
 [[package]]
 name = "windows_i686_gnu"
-version = "0.38.0"
+version = "0.42.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c98f2db372c23965c5e0f43896a8f0316dc0fbe48d1aa65bea9bdd295d43c15"
+checksum = "fbeae19f6716841636c28d695375df17562ca208b2b7d0dc47635a50ae6c5de7"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.38.0"
+version = "0.42.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cdf0569be0f2863ab6a12a6ba841fcfa7d107cbc7545a3ebd57685330db0a3ff"
+checksum = "84c12f65daa39dd2babe6e442988fc329d6243fdce47d7d2d155b8d874862246"
 
 [[package]]
 name = "windows_x86_64_gnu"
-version = "0.38.0"
+version = "0.42.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "905858262c8380a36f32cb8c1990d7e7c3b7a8170e58ed9a98ca6d940b7ea9f1"
+checksum = "bf7b1b21b5362cbc318f686150e5bcea75ecedc74dd157d874d754a2ca44b0ed"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.42.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09d525d2ba30eeb3297665bd434a54297e4170c7f1a44cad4ef58095b4cd2028"
 
 [[package]]
 name = "windows_x86_64_msvc"
-version = "0.38.0"
+version = "0.42.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "890c3c6341d441ffb38f705f47196e3665dc6dd79f6d72fa185d937326730561"
+checksum = "f40009d85759725a34da6d89a94e63d7bdc50a862acf0dbc7c8e488f1edcb6f5"
+
+[[package]]
+name = "yansi"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09041cd90cf85f7f8b2df60c646f853b7f535ce68f85244eb6731cf89fa498ec"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -70,9 +70,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.0.13"
+version = "4.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69d64e88428747154bd8bc378d178377ef4dace7a5735ca1f3855be72f2c2cb5"
+checksum = "6ea54a38e4bce14ff6931c72e5b3c43da7051df056913d4e7e1fcdb1c03df69d"
 dependencies = [
  "atty",
  "bitflags",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,9 +4,9 @@ version = 3
 
 [[package]]
 name = "aho-corasick"
-version = "0.7.18"
+version = "0.7.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e37cfd5e7657ada45f742d6e99ca5788580b5c529dc78faf11ece6dc702656f"
+checksum = "b4f55bd91a0978cbfd91c457a164bab8b4001c833b7f323132c0a4e1922dd44e"
 dependencies = [
  "memchr",
 ]
@@ -79,15 +79,15 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "3.1.18"
+version = "3.2.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2dbdf4bdacb33466e854ce889eee8dfd5729abf7ccd7664d0a2d60cd384440b"
+checksum = "86447ad904c7fb335a790c9d7fe3d0d971dc523b8ccd1561a520de9a85302750"
 dependencies = [
  "atty",
  "bitflags",
  "clap_lex",
  "indexmap",
- "lazy_static",
+ "once_cell",
  "strsim",
  "termcolor",
  "textwrap",
@@ -95,9 +95,9 @@ dependencies = [
 
 [[package]]
 name = "clap_lex"
-version = "0.2.0"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a37c35f1112dad5e6e0b1adaff798507497a18fceeb30cceb3bae7d1427b9213"
+checksum = "2850f2f5a82cbf437dd5af4d49848fbdfc27c157c3d010345776f952765261c5"
 dependencies = [
  "os_str_bytes",
 ]
@@ -134,9 +134,9 @@ checksum = "5827cebf4670468b8772dd191856768aedcb1b0278a04f989f7766351917b9dc"
 
 [[package]]
 name = "crossbeam-channel"
-version = "0.5.4"
+version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5aaa7bd5fb665c6864b5f963dd9097905c54125909c7aa94c9e18507cdbe6c53"
+checksum = "c2dd04ddaf88237dc3b8d8f9a3c1004b506b54b3313403944054d23c0870c521"
 dependencies = [
  "cfg-if",
  "crossbeam-utils",
@@ -144,9 +144,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-deque"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6455c0ca19f0d2fbf751b908d5c55c1f5cbc65e03c4225427254b46890bdde1e"
+checksum = "715e8152b692bba2d374b53d4875445368fdf21a94751410af607a5ac677d1fc"
 dependencies = [
  "cfg-if",
  "crossbeam-epoch",
@@ -155,33 +155,31 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.8"
+version = "0.9.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1145cf131a2c6ba0615079ab6a638f7e1973ac9c2634fcbeaaad6114246efe8c"
+checksum = "f916dfc5d356b0ed9dae65f1db9fc9770aa2851d2662b988ccf4fe3516e86348"
 dependencies = [
  "autocfg",
  "cfg-if",
  "crossbeam-utils",
- "lazy_static",
  "memoffset",
  "scopeguard",
 ]
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.8"
+version = "0.8.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0bf124c720b7686e3c2663cf54062ab0f68a88af2fb6a030e87e30bf721fcb38"
+checksum = "edbafec5fa1f196ca66527c1b12c2ec4745ca14b50f1ad8f9f6f720b55d11fac"
 dependencies = [
  "cfg-if",
- "lazy_static",
 ]
 
 [[package]]
 name = "either"
-version = "1.6.1"
+version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e78d4f1cc4ae33bbfc157ed5d5a5ef3bc29227303d595861deb238fcec4e9457"
+checksum = "90e5c1c8368803113bf0c9584fc495a58b86dc8a29edbf8fe877d21d9507e797"
 
 [[package]]
 name = "fnv"
@@ -191,9 +189,9 @@ checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "globset"
-version = "0.4.8"
+version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10463d9ff00a2a068db14231982f5132edebad0d7660cd956a1c30292dbcbfbd"
+checksum = "0a1e17342619edbc21a964c2afbeb6c820c6a2560032872f397bb97ea127bd0a"
 dependencies = [
  "aho-corasick",
  "bstr",
@@ -204,9 +202,9 @@ dependencies = [
 
 [[package]]
 name = "goblin"
-version = "0.5.2"
+version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cfeb764aa29a0774d290c2df134a37ab2e3c1ba59009162626658aabefda321a"
+checksum = "a7666983ed0dd8d21a6f6576ee00053ca0926fb281a5522577a4dbd0f1b54143"
 dependencies = [
  "log",
  "plain",
@@ -215,9 +213,9 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.11.2"
+version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab5ef0d4909ef3724cc8cce6ccc8572c5c817592e9285f5464f8e86f8bd3726e"
+checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 
 [[package]]
 name = "hermit-abi"
@@ -248,9 +246,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "1.8.2"
+version = "1.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6012d540c5baa3589337a98ce73408de9b5a25ec9fc2c6fd6be8f0d39e0ca5a"
+checksum = "10a35a97730320ffe8e2d410b5d3b69279b98d2c14bdb8b70ea89ecf7888d41e"
 dependencies = [
  "autocfg",
  "hashbrown",
@@ -258,9 +256,9 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "1.0.2"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "112c678d4050afce233f4f2852bb2eb519230b3cf12f33585275537d7e41578d"
+checksum = "6c8af84674fe1f223a982c933a0ee1086ac4d4052aa0fb8060c12c6ad838e754"
 
 [[package]]
 name = "lazy_static"
@@ -270,9 +268,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.126"
+version = "0.2.134"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "349d5a591cd28b49e1d1037471617a32ddcda5731b99419008085f72d5a53836"
+checksum = "329c933548736bc49fd575ee68c89e8be4d260064184389a5b77517cddd99ffb"
 
 [[package]]
 name = "log"
@@ -329,15 +327,15 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.12.0"
+version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7709cef83f0c1f58f666e746a08b21e0085f7440fa6a29cc194d68aac97a4225"
+checksum = "e82dad04139b71a90c080c8463fe0dc7902db5192d939bd0950f074d014339e1"
 
 [[package]]
 name = "os_str_bytes"
-version = "6.1.0"
+version = "6.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21326818e99cfe6ce1e524c2a805c189a99b5ae555a35d19f9a284b427d86afa"
+checksum = "9ff7415e9ae3fff1225851df9e0d9e4e5479f947619774677a63572e55e80eff"
 
 [[package]]
 name = "plain"
@@ -347,18 +345,18 @@ checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.39"
+version = "1.0.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c54b25569025b7fc9651de43004ae593a75ad88543b17178aa5e1b9c4f15f56f"
+checksum = "94e2ef8dbfc347b10c094890f778ee2e36ca9bb4262e86dc99cd217e35f3470b"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.18"
+version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1feb54ed693b93a84e14094943b84b7c4eae204c512b7ccb95ab0c66d278ad1"
+checksum = "bbe448f377a7d6961e30f5955f9b8d106c3f5e449d493ee1b125c1d43c2b5179"
 dependencies = [
  "proc-macro2",
 ]
@@ -389,9 +387,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.5.6"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d83f127d94bdbcda4c8cc2e50f6f84f4b611f69c902699ca385a39c3a75f9ff1"
+checksum = "4c4eb3267174b8c6c2f654116623910a0fef09c4753f8dd83db29c48a0df988b"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -400,15 +398,15 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.6.26"
+version = "0.6.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49b3de9ec5dc0a3417da371aab17d729997c15010e7fd24ff707773a33bddb64"
+checksum = "a3f87b73ce11b1619a3c6332f45341e0047173771e8b8b73f87bfeefb7b56244"
 
 [[package]]
 name = "ryu"
-version = "1.0.10"
+version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3f6f92acf49d1b98f7a81226834412ada05458b7364277387724a237f062695"
+checksum = "4501abdff3ae82a1c1b477a17252eb69cee9e66eb915c1abaa4f44d873df9f09"
 
 [[package]]
 name = "same-file"
@@ -447,18 +445,18 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.137"
+version = "1.0.145"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61ea8d54c77f8315140a05f4c7237403bf38b72704d031543aa1d16abbf517d1"
+checksum = "728eb6351430bccb993660dfffc5a72f91ccc1295abaa8ce19b27ebe4f75568b"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.137"
+version = "1.0.145"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f26faba0c3959972377d3b2d306ee9f71faee9714294e41bb777f83f88578be"
+checksum = "81fa1584d3d1bcacd84c277a0dfe21f5b0f6accf4a23d04d4c6d61f1af522b4c"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -467,9 +465,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.81"
+version = "1.0.85"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b7ce2b32a1aed03c558dc61a5cd328f15aff2dbc17daad8fb8af04d2100e15c"
+checksum = "e55a28e3aaef9d5ce0506d0a14dbba8054ddc7e499ef522dd8b26859ec9d4a44"
 dependencies = [
  "itoa",
  "ryu",
@@ -484,9 +482,9 @@ checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
 name = "syn"
-version = "1.0.96"
+version = "1.0.101"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0748dd251e24453cb8717f0354206b91557e4ec8703673a4b30208f2abaf1ebf"
+checksum = "e90cde112c4b9690b8cbe810cba9ddd8bc1d7472e2cae317b69e9438c1cba7d2"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -495,9 +493,9 @@ dependencies = [
 
 [[package]]
 name = "sysinfo"
-version = "0.24.2"
+version = "0.24.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a2809487b962344ca55d9aea565f9ffbcb6929780802217acc82561f6746770"
+checksum = "54cb4ebf3d49308b99e6e9dc95e989e2fdbdc210e4f67c39db0bb89ba927001c"
 dependencies = [
  "cfg-if",
  "core-foundation-sys",
@@ -519,9 +517,9 @@ dependencies = [
 
 [[package]]
 name = "textwrap"
-version = "0.15.0"
+version = "0.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1141d4d61095b28419e22cb0bbf02755f5e54e0526f97f1e3d1d160e60885fb"
+checksum = "949517c0cf1bf4ee812e2e07e08ab448e3ae0d23472aee8a06c985f0c8815b16"
 
 [[package]]
 name = "thread_local"
@@ -534,9 +532,9 @@ dependencies = [
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.0"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d22af068fba1eb5edcb4aea19d382b2a3deb4c8f9d475c589b6ada9e0fd493ee"
+checksum = "dcc811dc4066ac62f84f11307873c4850cb653bfa9b1719cee2bd2204a4bc5dd"
 
 [[package]]
 name = "walkdir"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -70,9 +70,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.0.4"
+version = "4.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f78ad8e84aa8e8aa3e821857be40eb4b925ff232de430d4dd2ae6aa058cbd92"
+checksum = "69d64e88428747154bd8bc378d178377ef4dace7a5735ca1f3855be72f2c2cb5"
 dependencies = [
  "atty",
  "bitflags",
@@ -228,9 +228,9 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "1.0.3"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c8af84674fe1f223a982c933a0ee1086ac4d4052aa0fb8060c12c6ad838e754"
+checksum = "4217ad341ebadf8d8e724e264f13e593e0648f5b3e94b3896a5df283be015ecc"
 
 [[package]]
 name = "lazy_static"
@@ -240,9 +240,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.134"
+version = "0.2.135"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "329c933548736bc49fd575ee68c89e8be4d260064184389a5b77517cddd99ffb"
+checksum = "68783febc7782c6c5cb401fbda4de5a9898be1762314da0bb2c10ced61f18b0c"
 
 [[package]]
 name = "log"
@@ -436,9 +436,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.85"
+version = "1.0.86"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e55a28e3aaef9d5ce0506d0a14dbba8054ddc7e499ef522dd8b26859ec9d4a44"
+checksum = "41feea4228a6f1cd09ec7a3593a682276702cd67b5273544757dae23c096f074"
 dependencies = [
  "itoa",
  "ryu",
@@ -453,9 +453,9 @@ checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
 name = "syn"
-version = "1.0.101"
+version = "1.0.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e90cde112c4b9690b8cbe810cba9ddd8bc1d7472e2cae317b69e9438c1cba7d2"
+checksum = "3fcd952facd492f9be3ef0d0b7032a6e442ee9b361d4acc2b1d0c4aaa5f613a1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -497,9 +497,9 @@ dependencies = [
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.4"
+version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcc811dc4066ac62f84f11307873c4850cb653bfa9b1719cee2bd2204a4bc5dd"
+checksum = "6ceab39d59e4c9499d4e5a8ee0e2735b891bb7308ac83dfb4e80cad195c9f6f3"
 
 [[package]]
 name = "walkdir"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,45 +1,53 @@
 [package]
-name = "checksec"
-version = "0.0.9"
 authors = ["etke"]
-edition = "2021"
-license = "Apache-2.0"
-description = "Fast multi-platform (ELF/PE/MachO) binary checksec command line utility and library."
-homepage = "https://crates.io/crates/checksec"
-repository = "https://github.com/etke/checksec.rs"
-documentation = "https://docs.rs/checksec"
-keywords = ["checksec", "binary", "security"]
 categories = ["command-line-utilities"]
+description = "Fast multi-platform (ELF/PE/MachO) binary checksec command line utility and library."
+documentation = "https://docs.rs/checksec"
+edition = "2021"
+homepage = "https://crates.io/crates/checksec"
 include = [
-    "src/*.rs",
-    "Cargo.toml",
-    "README.md",
-    "LICENSE"
+  "src/*.rs",
+  "Cargo.toml",
+  "README.md",
+  "LICENSE",
 ]
+keywords = ["checksec", "binary", "security"]
+license = "Apache-2.0"
+name = "checksec"
 readme = "README.md"
+repository = "https://github.com/etke/checksec.rs"
+version = "0.0.9"
 
 [profile.release]
-codegen-units = 1   # Reduce number of codegen units to increase optimizations
-lto = true          # Enable Link Time Optimization
-opt-level = 'z'     # Optimize for size
-panic = 'abort'     # Abort on panic
+codegen-units = 1 # Reduce number of codegen units to increase optimizations
+lto = true # Enable Link Time Optimization
+opt-level = 'z' # Optimize for size
+panic = 'abort' # Abort on panic
 
 [dependencies]
-clap = { version = "4.0.4", features = ["cargo"] }
-colored = { version = "2.0.0", optional = true }
-colored_json = { version = "3.0.1", optional = true }
+clap = {version = "4.0.13", features = ["cargo"]}
+colored = {version = "2.0.0", optional = true}
+colored_json = {version = "3.0.1", optional = true}
 goblin = "0.5.4"
 ignore = "0.4.18"
 memmap2 = "0.5.7"
 scroll = "0.11.0"
 scroll_derive = "0.11.0"
-serde = { version = "1.0.145", features = ["derive"] }
+serde = {version = "1.0.145", features = ["derive"]}
 serde_derive = "1.0.145"
-serde_json = "1.0.85"
+serde_json = "1.0.86"
 sysinfo = "0.26.4"
 
 [target.'cfg(target_os="windows")'.dependencies]
-windows = { version = "0.42.0", features = ["Win32_Foundation", "Win32_Security", "Win32_System_Diagnostics_Debug", "Win32_System_Diagnostics_ToolHelp", "Win32_System_Kernel", "Win32_System_Memory", "Win32_System_Threading"] }
+windows = {version = "0.42.0", features = [
+  "Win32_Foundation",
+  "Win32_Security",
+  "Win32_System_Diagnostics_Debug",
+  "Win32_System_Diagnostics_ToolHelp",
+  "Win32_System_Kernel",
+  "Win32_System_Memory",
+  "Win32_System_Threading",
+]}
 
 [lib]
 name = "checksec"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,21 +25,21 @@ opt-level = 'z'     # Optimize for size
 panic = 'abort'     # Abort on panic
 
 [dependencies]
-clap = { version = "3.2.22", features = ["cargo"] }
+clap = { version = "4.0.4", features = ["cargo"] }
 colored = { version = "2.0.0", optional = true }
-colored_json = { version = "2.1.0", optional = true }
+colored_json = { version = "3.0.1", optional = true }
 goblin = "0.5.4"
 ignore = "0.4.18"
-memmap = "0.7.0"
+memmap2 = "0.5.7"
 scroll = "0.11.0"
 scroll_derive = "0.11.0"
 serde = { version = "1.0.145", features = ["derive"] }
 serde_derive = "1.0.145"
 serde_json = "1.0.85"
-sysinfo = "0.24.7"
+sysinfo = "0.26.4"
 
 [target.'cfg(target_os="windows")'.dependencies]
-windows = { version = "0.38.0", features = ["Win32_Foundation", "Win32_Security", "Win32_System_Diagnostics_Debug", "Win32_System_Diagnostics_ToolHelp", "Win32_System_Kernel", "Win32_System_Memory", "Win32_System_Threading"] }
+windows = { version = "0.42.0", features = ["Win32_Foundation", "Win32_Security", "Win32_System_Diagnostics_Debug", "Win32_System_Diagnostics_ToolHelp", "Win32_System_Kernel", "Win32_System_Memory", "Win32_System_Threading"] }
 
 [lib]
 name = "checksec"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,18 +25,18 @@ opt-level = 'z'     # Optimize for size
 panic = 'abort'     # Abort on panic
 
 [dependencies]
-clap = { version = "3.1.18", features = ["cargo"] }
+clap = { version = "3.2.22", features = ["cargo"] }
 colored = { version = "2.0.0", optional = true }
 colored_json = { version = "2.1.0", optional = true }
-goblin = "0.5.2"
+goblin = "0.5.4"
 ignore = "0.4.18"
 memmap = "0.7.0"
 scroll = "0.11.0"
 scroll_derive = "0.11.0"
-serde = { version = "1.0.137", features = ["derive"] }
-serde_derive = "1.0.137"
-serde_json = "1.0.81"
-sysinfo = "0.24.2"
+serde = { version = "1.0.145", features = ["derive"] }
+serde_derive = "1.0.145"
+serde_json = "1.0.85"
+sysinfo = "0.24.7"
 
 [target.'cfg(target_os="windows")'.dependencies]
 windows = { version = "0.38.0", features = ["Win32_Foundation", "Win32_Security", "Win32_System_Diagnostics_Debug", "Win32_System_Diagnostics_ToolHelp", "Win32_System_Kernel", "Win32_System_Memory", "Win32_System_Threading"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,12 +20,12 @@ version = "0.0.9"
 
 [profile.release]
 codegen-units = 1 # Reduce number of codegen units to increase optimizations
-lto = true # Enable Link Time Optimization
-opt-level = 'z' # Optimize for size
-panic = 'abort' # Abort on panic
+lto = true        # Enable Link Time Optimization
+opt-level = 'z'   # Optimize for size
+panic = 'abort'   # Abort on panic
 
 [dependencies]
-clap = {version = "4.0.13", features = ["cargo"]}
+clap = {version = "4.0.14", features = ["cargo"]}
 colored = {version = "2.0.0", optional = true}
 colored_json = {version = "3.0.1", optional = true}
 goblin = "0.5.4"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "checksec"
 version = "0.0.9"
 authors = ["etke"]
-edition = "2018"
+edition = "2021"
 license = "Apache-2.0"
 description = "Fast multi-platform (ELF/PE/MachO) binary checksec command line utility and library."
 homepage = "https://crates.io/crates/checksec"

--- a/examples/pe_has_aslr_gs.rs
+++ b/examples/pe_has_aslr_gs.rs
@@ -1,10 +1,10 @@
 extern crate checksec;
 extern crate goblin;
-extern crate memmap;
+extern crate memmap2;
 
 use checksec::pe::Properties;
 use goblin::pe::PE;
-use memmap::Mmap;
+use memmap2::Mmap;
 use std::{env, fs};
 
 fn main() {

--- a/examples/pe_print_checksec_results.rs
+++ b/examples/pe_print_checksec_results.rs
@@ -1,10 +1,10 @@
 extern crate checksec;
 extern crate goblin;
-extern crate memmap;
+extern crate memmap2;
 
 use checksec::pe::CheckSecResults;
 use goblin::Object;
-use memmap::Mmap;
+use memmap2::Mmap;
 use std::{env, fs};
 
 fn main() {

--- a/src/main.rs
+++ b/src/main.rs
@@ -277,6 +277,7 @@ fn main() {
                 .long("maps")
                 .action(ArgAction::SetTrue)
                 .help("Include process memory maps (linux only)")
+                .requires("pid")
                 .requires("process")
                 .requires("process-all")
                 .conflicts_with_all(&["directory", "file"]),
@@ -326,9 +327,11 @@ fn main() {
     let procall = args.get_flag("process-all");
 
     let format = if args.get_flag("json") {
-        output::Format::Json
-    } else if args.get_flag("pretty") {
-        output::Format::JsonPretty
+        if args.get_flag("pretty") {
+            output::Format::JsonPretty
+        } else {
+            output::Format::Json
+        }
     } else {
         output::Format::Text
     };

--- a/src/main.rs
+++ b/src/main.rs
@@ -251,18 +251,18 @@ fn main() {
         .version(crate_version!())
         .arg_required_else_help(true)
         .arg(
-            Arg::new("file")
-                .short('f')
-                .long("file")
-                .value_name("FILE")
-                .help("Target file"),
-        )
-        .arg(
             Arg::new("directory")
                 .short('d')
                 .long("directory")
                 .value_name("DIRECTORY")
                 .help("Target directory"),
+        )
+        .arg(
+            Arg::new("file")
+                .short('f')
+                .long("file")
+                .value_name("FILE")
+                .help("Target file"),
         )
         .arg(
             Arg::new("json")
@@ -289,6 +289,15 @@ fn main() {
                 .help("Disables color output"),
         )
         .arg(
+            Arg::new("pid")
+                .help(
+                    "Process ID of running process to check\n\
+                    (comma separated for multiple PIDs)",
+                )
+                .long("pid")
+                .value_name("PID"),
+        )
+        .arg(
             Arg::new("pretty")
                 .long("pretty")
                 .action(ArgAction::SetTrue)
@@ -301,15 +310,6 @@ fn main() {
                 .long("process")
                 .value_name("NAME")
                 .help("Name of running process to check"),
-        )
-        .arg(
-            Arg::new("pid")
-                .help(
-                    "Process ID of running process to check\n\
-                    (comma separated for multiple PIDs)",
-                )
-                .long("pid")
-                .value_name("PID"),
         )
         .arg(
             Arg::new("process-all")

--- a/src/main.rs
+++ b/src/main.rs
@@ -302,10 +302,15 @@ fn main() {
                 .value_name("NAME")
                 .help("Name of running process to check"),
         )
-        .arg(Arg::new("pid").long("pid").value_name("PID").help(
-            "Process ID of running process to check\n\
+        .arg(
+            Arg::new("pid")
+                .help(
+                    "Process ID of running process to check\n\
                     (comma separated for multiple PIDs)",
-        ))
+                )
+                .long("pid")
+                .value_name("PID"),
+        )
         .arg(
             Arg::new("process-all")
                 .short('P')

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,14 +6,15 @@ extern crate serde_json;
 extern crate sysinfo;
 
 use clap::{
-    crate_authors, crate_description, crate_version, Arg, ArgGroup, Command,
+    crate_authors, crate_description, crate_version, Arg, ArgAction, ArgGroup,
+    Command,
 };
 use goblin::error::Error;
 #[cfg(feature = "macho")]
 use goblin::mach::Mach;
 use goblin::Object;
 use ignore::Walk;
-use memmap::Mmap;
+use memmap2::Mmap;
 use serde_json::{json, to_string_pretty};
 use sysinfo::{
     PidExt, ProcessExt, ProcessRefreshKind, RefreshKind, System, SystemExt,
@@ -24,6 +25,7 @@ use std::{env, fmt, fs, process};
 
 #[cfg(feature = "color")]
 use colored::Colorize;
+
 #[cfg(feature = "color")]
 use colored_json::to_colored_json_auto;
 
@@ -249,33 +251,32 @@ fn main() {
         .version(crate_version!())
         .arg_required_else_help(true)
         .arg(
-            Arg::new("directory")
-                .short('d')
-                .long("directory")
-                .value_name("DIRECTORY")
-                .help("Target directory")
-                .takes_value(true),
-        )
-        .arg(
             Arg::new("file")
                 .short('f')
                 .long("file")
                 .value_name("FILE")
-                .help("Target file")
-                .takes_value(true),
+                .help("Target file"),
+        )
+        .arg(
+            Arg::new("directory")
+                .short('d')
+                .long("directory")
+                .value_name("DIRECTORY")
+                .help("Target directory"),
         )
         .arg(
             Arg::new("json")
                 .short('j')
                 .long("json")
+                .action(ArgAction::SetTrue)
                 .help("Output in json format"),
         )
         .arg(
             Arg::new("maps")
                 .short('m')
                 .long("maps")
-                .help("Include process memory maps (Linux only)")
-                .requires("pid")
+                .action(ArgAction::SetTrue)
+                .help("Include process memory maps (linux only)")
                 .requires("process")
                 .requires("process-all")
                 .conflicts_with_all(&["directory", "file"]),
@@ -283,21 +284,13 @@ fn main() {
         .arg(
             Arg::new("no-color")
                 .long("no-color")
+                .action(ArgAction::SetTrue)
                 .help("Disables color output"),
-        )
-        .arg(
-            Arg::new("pid")
-                .long("pid")
-                .value_name("PID")
-                .help(
-                    "Process ID of running process to check\n\
-                    (comma separated for multiple PIDs)",
-                )
-                .takes_value(true),
         )
         .arg(
             Arg::new("pretty")
                 .long("pretty")
+                .action(ArgAction::SetTrue)
                 .help("Human readable json output")
                 .requires("json"),
         )
@@ -306,13 +299,17 @@ fn main() {
                 .short('p')
                 .long("process")
                 .value_name("NAME")
-                .help("Name of running process to check")
-                .takes_value(true),
+                .help("Name of running process to check"),
         )
+        .arg(Arg::new("pid").long("pid").value_name("PID").help(
+            "Process ID of running process to check\n\
+                    (comma separated for multiple PIDs)",
+        ))
         .arg(
             Arg::new("process-all")
                 .short('P')
                 .long("process-all")
+                .action(ArgAction::SetTrue)
                 .help("Check all running processes"),
         )
         .group(
@@ -322,27 +319,25 @@ fn main() {
         )
         .get_matches();
 
-    let file = args.value_of("file");
-    let directory = args.value_of("directory");
-    let procids = args.value_of("pid");
-    let procname = args.value_of("process");
-    let procall = args.is_present("process-all");
+    let file = args.get_one::<String>("file");
+    let directory = args.get_one::<String>("directory");
+    let procids = args.get_one::<String>("pid");
+    let procname = args.get_one::<String>("process");
+    let procall = args.get_flag("process-all");
 
-    let format = if args.is_present("json") {
-        if args.is_present("pretty") {
-            output::Format::JsonPretty
-        } else {
-            output::Format::Json
-        }
+    let format = if args.get_flag("json") {
+        output::Format::Json
+    } else if args.get_flag("pretty") {
+        output::Format::JsonPretty
     } else {
         output::Format::Text
     };
 
     let settings = output::Settings::set(
         #[cfg(feature = "color")]
-        !args.is_present("no-color"),
+        !args.get_flag("no-color"),
         format,
-        args.is_present("maps"),
+        args.get_flag("maps"),
     );
 
     if procall {

--- a/src/pe.rs
+++ b/src/pe.rs
@@ -7,7 +7,7 @@ use goblin::pe::{
     data_directories::DataDirectory, options::ParseOptions,
     section_table::SectionTable,
 };
-use memmap::Mmap;
+use memmap2::Mmap;
 use scroll::Pread;
 use serde::{Deserialize, Serialize};
 use std::fmt;
@@ -271,7 +271,7 @@ impl fmt::Display for ASLR {
 /// ```rust
 /// use checksec::pe::{Properties, CheckSecResults};
 /// use goblin::{pe::PE, Object};
-/// use memmap::Mmap;
+/// use memmap2::Mmap;
 /// use std::fs;
 ///
 /// pub fn print_results(binary: &String) {
@@ -414,7 +414,7 @@ impl fmt::Display for CheckSecResults {
 /// ```rust
 /// use checksec::pe::Properties;
 /// use goblin::pe::PE;
-/// use memmap::Mmap;
+/// use memmap2::Mmap;
 /// use std::fs;
 ///
 /// pub fn print_results(binary: &String) {
@@ -443,10 +443,10 @@ pub trait Properties {
     /// `IMAGE_OPTIONAL_HEADER32/64`
     ///
     /// requires a
-    /// [`memmap::Mmap`](https://docs.rs/memmap/0.7.0/memmap/struct.Mmap.html)
+    /// [`memmap2::Mmap`](https://docs.rs/memmap2/0.5.7/memmap2/struct.Mmap.html)
     /// of the original file to read & parse required information from the
     /// underlying binary file
-    fn has_authenticode(&self, mem: &memmap::Mmap) -> bool;
+    fn has_authenticode(&self, mem: &memmap2::Mmap) -> bool;
     /// check for `IMAGE_DLLCHARACTERISTICS_GUARD_CF` *(0x4000)* in
     /// `DllCharacteristics` within the `IMAGE_OPTIONAL_HEADER32/64`
     fn has_cfg(&self) -> bool;
@@ -467,10 +467,10 @@ pub trait Properties {
     /// `IMAGE_OPTIONAL_HEADER32/64`
     ///
     /// requires a
-    /// [`memmap::Mmap`](https://docs.rs/memmap/0.7.0/memmap/struct.Mmap.html)
+    /// [`memmap2::Mmap`](https://docs.rs/memmap2/0.5.7/memmap2/struct.Mmap.html)
     /// of the original file to read & parse required information from the
     /// underlying binary file
-    fn has_gs(&self, mem: &memmap::Mmap) -> bool;
+    fn has_gs(&self, mem: &memmap2::Mmap) -> bool;
     /// check for `IMAGE_DLLCHARACTERISTICS_HIGH_ENTROPY_VA` *(`0x0020`)* in
     /// `DllCharacteristics` within the `IMAGE_OPTIONAL_HEADER32/64`
     fn has_high_entropy_va(&self) -> bool;
@@ -483,18 +483,18 @@ pub trait Properties {
     /// from the `IMAGE_OPTIONAL_HEADER32/64`
     ///
     /// requires a
-    /// [`memmap::Mmap`](https://docs.rs/memmap/0.7.0/memmap/struct.Mmap.html)
+    /// [`memmap2::Mmap`](https://docs.rs/memmap2/0.5.7/memmap2/struct.Mmap.html)
     /// of the original file to read & parse required information from the
     /// underlying binary file
-    fn has_rfg(&self, mem: &memmap::Mmap) -> bool;
+    fn has_rfg(&self, mem: &memmap2::Mmap) -> bool;
     /// check `shandler_count` from `LOAD_CONFIG` in `IMAGE_DATA_DIRECTORY`
     /// linked from the the `IMAGE_OPTIONAL_HEADER32/64`
     ///
     /// requires a
-    /// [`memmap::Mmap`](https://docs.rs/memmap/0.7.0/memmap/struct.Mmap.html)
+    /// [`memmap2::Mmap`](https://docs.rs/memmap2/0.5.7/memmap2/struct.Mmap.html)
     /// of the original file to read and parse required information from the
     /// underlying binary file
-    fn has_safe_seh(&self, mem: &memmap::Mmap) -> bool;
+    fn has_safe_seh(&self, mem: &memmap2::Mmap) -> bool;
     /// check `IMAGE_DLLCHARACTERISTICS_NO_SEH` from the
     /// `IMAGE_OPTIONAL_HEADER32/64`
     fn has_seh(&self) -> bool;
@@ -508,7 +508,7 @@ impl Properties for PE<'_> {
         }
         ASLR::None
     }
-    fn has_authenticode(&self, mem: &memmap::Mmap) -> bool {
+    fn has_authenticode(&self, mem: &memmap2::Mmap) -> bool {
         // requires running platform to be Windows for verification
         // just check for existence right now
         if let Some(optional_header) = self.header.optional_header {
@@ -591,7 +591,7 @@ impl Properties for PE<'_> {
         }
         false
     }
-    fn has_gs(&self, mem: &memmap::Mmap) -> bool {
+    fn has_gs(&self, mem: &memmap2::Mmap) -> bool {
         if let Some(optional_header) = self.header.optional_header {
             let file_alignment = optional_header.windows_fields.file_alignment;
             let sections = &self.sections;
@@ -632,7 +632,7 @@ impl Properties for PE<'_> {
         }
         false
     }
-    fn has_rfg(&self, mem: &memmap::Mmap) -> bool {
+    fn has_rfg(&self, mem: &memmap2::Mmap) -> bool {
         if let Some(optional_header) = self.header.optional_header {
             let file_alignment = optional_header.windows_fields.file_alignment;
             let sections = &self.sections;
@@ -657,7 +657,7 @@ impl Properties for PE<'_> {
         }
         false
     }
-    fn has_safe_seh(&self, mem: &memmap::Mmap) -> bool {
+    fn has_safe_seh(&self, mem: &memmap2::Mmap) -> bool {
         if let Some(optional_header) = self.header.optional_header {
             let file_alignment = optional_header.windows_fields.file_alignment;
             let sections = &self.sections;

--- a/src/proc.rs
+++ b/src/proc.rs
@@ -486,7 +486,7 @@ fn set_debug_privilege() -> Result<(), Error> {
             .collect();
         if unsafe {
             LookupPrivilegeValueW(
-                PCWSTR::default(),
+                PCWSTR::null(),
                 PCWSTR(wprivstr.as_ptr()),
                 &mut luid,
             )
@@ -505,10 +505,10 @@ fn set_debug_privilege() -> Result<(), Error> {
                 AdjustTokenPrivileges(
                     htoken,
                     false,
-                    &tkp,
+                    Some(&tkp),
                     mem::size_of::<TOKEN_PRIVILEGES>() as u32,
-                    &mut TOKEN_PRIVILEGES::default(),
-                    &mut 0_u32,
+                    Some(&mut TOKEN_PRIVILEGES::default()),
+                    Some(&mut 0_u32),
                 )
             }
             .as_bool()
@@ -552,7 +552,7 @@ fn fetch_modules(
         let retsize = unsafe {
             VirtualQueryEx(
                 proc.hprocess,
-                region.start as *const c_void,
+                Some(region.start as *const c_void),
                 &mut lpbuffer,
                 size,
             )
@@ -602,7 +602,7 @@ fn fetch_heaps(
             let _ = unsafe {
                 VirtualQueryEx(
                     proc.hprocess,
-                    lphl.th32HeapID as *const std::ffi::c_void,
+                    Some(lphl.th32HeapID as *const std::ffi::c_void),
                     &mut lpbuffer,
                     mem::size_of::<MEMORY_BASIC_INFORMATION>(),
                 )
@@ -631,7 +631,7 @@ fn fetch_heaps(
                 let retsize = unsafe {
                     VirtualQueryEx(
                         proc.hprocess,
-                        region.start as *const c_void,
+                        Some(region.start as *const c_void),
                         &mut lpbuffer,
                         size,
                     )
@@ -716,7 +716,7 @@ fn fetch_stacks(
                         let _ = unsafe {
                             VirtualQueryEx(
                                 proc.hprocess,
-                                sp as *const c_void,
+                                Some(sp as *const c_void),
                                 &mut lpbuffer,
                                 mem::size_of::<MEMORY_BASIC_INFORMATION>(),
                             )


### PR DESCRIPTION
this PR upgrades the dependencies, the only one involving some changes in the code is Clap to the next major 
It also replaces memmap with memmap2 since the original crate is unmaintained

I only tested on macOS so it's better to give it a try on Windows since the windows crate has been updated as well