### PR TITLE
Linux/ELF: Add option to scan loaded shared libraries

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -56,9 +56,13 @@ dependencies = [
  "clap",
  "colored",
  "colored_json",
+ "either",
+ "glob",
  "goblin",
  "ignore",
+ "itertools",
  "memmap2",
+ "rayon",
  "scroll",
  "scroll_derive",
  "serde",
@@ -166,15 +170,21 @@ dependencies = [
 
 [[package]]
 name = "either"
-version = "1.8.0"
+version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90e5c1c8368803113bf0c9584fc495a58b86dc8a29edbf8fe877d21d9507e797"
+checksum = "7fcaabb2fef8c910e7f4c7ce9f67a1283a1715879a7c230ca9d6d1ae31f16d91"
 
 [[package]]
 name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
+name = "glob"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b919933a397b79c37e33b77bb2aa3dc8eb6e165ad809e58ff75bc7db2e34574"
 
 [[package]]
 name = "globset"
@@ -225,6 +235,15 @@ dependencies = [
  "thread_local",
  "walkdir",
  "winapi-util",
+]
+
+[[package]]
+name = "itertools"
+version = "0.10.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
+dependencies = [
+ "either",
 ]
 
 [[package]]
@@ -335,21 +354,19 @@ dependencies = [
 
 [[package]]
 name = "rayon"
-version = "1.5.3"
+version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd99e5772ead8baa5215278c9b15bf92087709e9c1b2d1f97cdb5a183c933a7d"
+checksum = "1d2df5196e37bcc87abebc0053e20787d73847bb33134a69841207dd0a47f03b"
 dependencies = [
- "autocfg",
- "crossbeam-deque",
  "either",
  "rayon-core",
 ]
 
 [[package]]
 name = "rayon-core"
-version = "1.9.3"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "258bcdb5ac6dad48491bb2992db6b7cf74878b0384908af124823d118c99683f"
+checksum = "4b8f95bd6966f5c87776639160a66bd8ab9895d9d4ab01ddba9fc60661aebe8d"
 dependencies = [
  "crossbeam-channel",
  "crossbeam-deque",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,9 +28,13 @@ panic = 'abort'   # Abort on panic
 clap = {version = "4.0.14", features = ["cargo"]}
 colored = {version = "2.0.0", optional = true}
 colored_json = {version = "3.0.1", optional = true}
+either = "1.8.1"
+glob = "0.3.0"
 goblin = "0.6.0"
 ignore = "0.4.18"
+itertools = "0.10.5"
 memmap2 = "0.5.7"
+rayon = "1.7.0"
 scroll = "0.11.0"
 scroll_derive = "0.11.0"
 serde = {version = "1.0.145", features = ["derive"]}

--- a/src/ldso.rs
+++ b/src/ldso.rs
@@ -1,0 +1,130 @@
+use crate::ldso::LdSoError::{IncludeDepth, InvalidFormat};
+use std::path::{Path, PathBuf};
+use std::{fmt, fs, io};
+
+#[derive(Clone)]
+pub struct LdSoLookup {
+    lookup_dirs: Vec<PathBuf>,
+}
+
+impl LdSoLookup {
+    #[must_use]
+    pub fn search(&self, filename: &str) -> Option<PathBuf> {
+        for dir in &self.lookup_dirs {
+            let path = dir.join(filename);
+            if path.is_file() {
+                return Some(path);
+            }
+        }
+        None
+    }
+}
+
+pub enum LdSoError {
+    /// I/O error
+    IO(io::Error),
+    /// Invalid format
+    InvalidFormat(String),
+    /// Pattern error
+    Pattern(glob::PatternError, PathBuf),
+    /// Globbing error
+    Glob(glob::GlobError, PathBuf),
+    /// Include depth exhaustion
+    IncludeDepth(PathBuf),
+}
+
+impl fmt::Display for LdSoError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::IO(err) => err.fmt(f),
+            Self::InvalidFormat(str) => str.fmt(f),
+            Self::Pattern(perr, path) => {
+                write!(f, "Failed to follow glob {}: {}", path.display(), perr)
+            }
+            Self::Glob(gerr, path) => {
+                write!(f, "Failed to match glob {}: {}", path.display(), gerr)
+            }
+            Self::IncludeDepth(path) => {
+                write!(f, "Maximum include depth reached: {}", path.display())
+            }
+        }
+    }
+}
+
+impl From<io::Error> for LdSoError {
+    fn from(e: io::Error) -> Self {
+        LdSoError::IO(e)
+    }
+}
+
+impl LdSoLookup {
+    fn parse_ldso_conf_file(
+        conffile: &Path,
+        include_depth: u8,
+    ) -> Result<Vec<PathBuf>, LdSoError> {
+        if include_depth > 4 {
+            return Err(IncludeDepth(conffile.to_path_buf()));
+        }
+
+        let mut lookup_paths: Vec<PathBuf> = Vec::new();
+        let content = fs::read_to_string(conffile)?;
+
+        for line in content.lines() {
+            let line = line.trim();
+
+            if line.is_empty() || line.starts_with('#') {
+                continue;
+            }
+
+            if let Some(include_path) = line.strip_prefix("include ") {
+                if !include_path.starts_with('/') {
+                    return Err(InvalidFormat(format!(
+                        "Invalid include path: {include_path}"
+                    )));
+                }
+                for file in glob::glob(include_path).map_err(|e| {
+                    LdSoError::Pattern(e, PathBuf::from(include_path))
+                })? {
+                    let file = file.map_err(|e| {
+                        LdSoError::Glob(e, PathBuf::from(include_path))
+                    })?;
+                    lookup_paths.append(
+                        &mut LdSoLookup::parse_ldso_conf_file(
+                            &file,
+                            include_depth + 1,
+                        )?,
+                    );
+                }
+                continue;
+            }
+
+            if line.starts_with('/') {
+                lookup_paths.push(PathBuf::from(
+                    line.split('#').next().ok_or_else(|| {
+                        InvalidFormat(format!("Invalid path line: {line}"))
+                    })?,
+                ));
+                continue;
+            }
+
+            return Err(InvalidFormat(format!("Invalid line: {line}")));
+        }
+
+        Ok(lookup_paths)
+    }
+
+    /// Initialize a lookup handle from the ld.so.conf configuration of the
+    /// system.
+    ///
+    /// # Errors
+    /// Will fail if the ld.so.conf configuration can not be read or has an
+    /// invalid format.
+    pub fn gen_lookup_dirs() -> Result<LdSoLookup, LdSoError> {
+        Ok(LdSoLookup {
+            lookup_dirs: LdSoLookup::parse_ldso_conf_file(
+                Path::new("/etc/ld.so.conf"),
+                0,
+            )?,
+        })
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -46,6 +46,8 @@
 
 #[cfg(feature = "elf")]
 pub mod elf;
+#[cfg(target_os = "linux")]
+pub mod ldso;
 #[cfg(feature = "macho")]
 pub mod macho;
 pub mod macros;

--- a/src/macho.rs
+++ b/src/macho.rs
@@ -32,7 +32,7 @@ const MH_NO_HEAP_EXECUTION: u32 = 0x0100_0000;
 /// }
 /// ```
 #[allow(clippy::struct_excessive_bools)]
-#[derive(Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct CheckSecResults {
     /// Automatic Reference Counting
     pub arc: bool,

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -26,3 +26,19 @@ macro_rules! underline {
         $str
     };
 }
+
+#[macro_export]
+#[cfg(feature = "color")]
+macro_rules! bold {
+    ($str:expr) => {
+        $str.bold()
+    };
+}
+
+#[macro_export]
+#[cfg(not(feature = "color"))]
+macro_rules! bold {
+    ($str:expr) => {
+        $str
+    };
+}

--- a/src/output.rs
+++ b/src/output.rs
@@ -14,25 +14,31 @@ pub struct Settings {
     pub color: bool,
     pub format: Format,
     pub maps: bool,
+    pub libraries: bool,
 }
 
 impl Settings {
     #[must_use]
     #[cfg(feature = "color")]
-    pub fn set(color: bool, format: Format, maps: bool) -> Self {
+    pub fn set(
+        color: bool,
+        format: Format,
+        maps: bool,
+        libraries: bool,
+    ) -> Self {
         if color {
             // honor NO_COLOR if it is set within the environment
             if env::var("NO_COLOR").is_ok() {
-                return Self { color: false, format, maps };
+                return Self { color: false, format, maps, libraries };
             }
         } else {
             control::set_override(false);
         }
-        Self { color, format, maps }
+        Self { color, format, maps, libraries }
     }
     #[must_use]
     #[cfg(not(feature = "color"))]
-    pub fn set(format: Format, maps: bool) -> Self {
-        Self { format, maps }
+    pub fn set(format: Format, maps: bool, libraries: bool) -> Self {
+        Self { format, maps, libraries }
     }
 }

--- a/src/pe.rs
+++ b/src/pe.rs
@@ -230,7 +230,7 @@ fn get_load_config_val(
 }
 
 /// Address Space Layout Randomization: `None`, `DYNBASE`, or `HIGHENTROPYVA`
-#[derive(Deserialize, Serialize, Debug)]
+#[derive(Clone, Deserialize, Serialize, Debug)]
 pub enum ASLR {
     None,
     DynamicBase,
@@ -295,7 +295,7 @@ impl fmt::Display for ASLR {
 /// object and a read-only memory-mapped version of the original file
 /// must be provided for evaluating PE32/32+ binaries.
 #[allow(clippy::struct_excessive_bools)]
-#[derive(Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct CheckSecResults {
     /// Address Space Layout Randomization
     pub aslr: ASLR,

--- a/src/proc.rs
+++ b/src/proc.rs
@@ -340,30 +340,39 @@ impl WinProcInfo {
 #[derive(Deserialize, Serialize)]
 pub struct Process {
     pub pid: usize,
-    pub binary: Vec<Binary>,
+    pub binary: Binary,
     #[cfg(all(
         feature = "maps",
         any(target_os = "linux", target_os = "windows")
     ))]
     pub maps: Option<Vec<MapEntry>>,
+    pub libraries: Option<Vec<Binary>>,
 }
 impl Process {
     #[cfg(any(not(feature = "maps"), target_os = "macos"))]
-    pub fn new(pid: usize, binary: Vec<Binary>) -> Self {
-        Self { pid, binary }
+    pub fn new(
+        pid: usize,
+        binary: Binary,
+        libraries: Option<Vec<Binary>>,
+    ) -> Self {
+        Self { pid, binary, libraries }
     }
     #[cfg(all(
         feature = "maps",
         any(target_os = "linux", target_os = "windows")
     ))]
-    pub fn new(pid: usize, binary: Vec<Binary>) -> Self {
+    pub fn new(
+        pid: usize,
+        binary: Binary,
+        libraries: Option<Vec<Binary>>,
+    ) -> Self {
         match Process::parse_maps(pid) {
-            Ok(maps) => Self { pid, binary, maps: Some(maps) },
+            Ok(maps) => Self { pid, binary, maps: Some(maps), libraries },
             Err(e) => {
                 eprintln!(
                     "Failed to parse maps for process with ID {pid}: {e}"
                 );
-                Self { pid, binary, maps: None }
+                Self { pid, binary, maps: None, libraries }
             }
         }
     }

--- a/src/shared.rs
+++ b/src/shared.rs
@@ -3,16 +3,17 @@
 use colored::Colorize;
 use serde::{Deserialize, Serialize};
 use std::fmt;
+use std::ops::Deref;
 
 /// Split contents of `DT_RPATH`/`DT_RUNPATH` or @rpath entries
-#[derive(Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize)]
 pub enum Rpath {
     None,
     Yes(String),
     YesRW(String),
 }
 /// wrapper for Vec<Rpath> to allow easy color output per path entry
-#[derive(Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct VecRpath {
     paths: Vec<Rpath>,
 }
@@ -20,6 +21,12 @@ impl VecRpath {
     #[must_use]
     pub fn new(v: Vec<Rpath>) -> Self {
         Self { paths: v }
+    }
+}
+impl Deref for VecRpath {
+    type Target = Vec<Rpath>;
+    fn deref(&self) -> &Self::Target {
+        &self.paths
     }
 }
 #[cfg(not(feature = "color"))]


### PR DESCRIPTION
Dynamic linking is the standard on Linux.  Thus the hardening of dynamic loaded shared libraries can affect programs as well.

Add a an option to scan all dynamic libraries for a binary/process.  For binaries the list of libraries is taken from the ELF information and for processes all executable mapped memory regions backed up by a file are scanned.

**Remarks**
I renamed the structs `Binary` to `Blob` and `Binaries` to `Binary` and dropped the formatting inside of Blob (previously Binary) to get the formatting in `print_binary_results()` and `print_process_results()` working.

The *main.rs* file now has several parsing related functions which might be subject of refactoring into a new file.

To speed the scanning of libraries up (especially for scanning directories or all running processes) rayon's parallel iterators are used.