### PR TITLE
Rework command line interface

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -53,6 +53,7 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 name = "checksec"
 version = "0.0.9"
 dependencies = [
+ "atty",
  "clap",
  "colored",
  "colored_json",
@@ -82,10 +83,24 @@ checksum = "6ea54a38e4bce14ff6931c72e5b3c43da7051df056913d4e7e1fcdb1c03df69d"
 dependencies = [
  "atty",
  "bitflags",
+ "clap_derive",
  "clap_lex",
  "once_cell",
  "strsim",
  "termcolor",
+]
+
+[[package]]
+name = "clap_derive"
+version = "4.0.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c42f169caba89a7d512b5418b09864543eeb4d497416c917d7137863bd2076ad"
+dependencies = [
+ "heck",
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -210,6 +225,12 @@ dependencies = [
  "plain",
  "scroll",
 ]
+
+[[package]]
+name = "heck"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2540771e65fc8cb83cd6e8a237f70c319bd5c29f78ed1084ba5d50eeac86f7f9"
 
 [[package]]
 name = "hermit-abi"
@@ -343,6 +364,30 @@ name = "plain"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
+
+[[package]]
+name = "proc-macro-error"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
+dependencies = [
+ "proc-macro-error-attr",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "version_check",
+]
+
+[[package]]
+name = "proc-macro-error-attr"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "version_check",
+]
 
 [[package]]
 name = "proc-macro2"
@@ -528,6 +573,12 @@ name = "unicode-ident"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ceab39d59e4c9499d4e5a8ee0e2735b891bb7308ac83dfb4e80cad195c9f6f3"
+
+[[package]]
+name = "version_check"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 
 [[package]]
 name = "walkdir"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,8 @@ opt-level = 'z'   # Optimize for size
 panic = 'abort'   # Abort on panic
 
 [dependencies]
-clap = {version = "4.0.14", features = ["cargo"]}
+atty = "0.2.14"
+clap = {version = "4.0.14", features = ["cargo", "derive"]}
 colored = {version = "2.0.0", optional = true}
 colored_json = {version = "3.0.1", optional = true}
 either = "1.8.1"

--- a/src/output.rs
+++ b/src/output.rs
@@ -1,44 +1,50 @@
+use clap::ValueEnum;
 #[cfg(feature = "color")]
 use colored::control;
 #[cfg(feature = "color")]
 use std::env;
 
+#[derive(Clone, Debug, ValueEnum)]
 pub enum Format {
     Text,
     Json,
     JsonPretty,
 }
 
+impl std::fmt::Display for Format {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Text => write!(f, "text"),
+            Self::Json => write!(f, "json"),
+            Self::JsonPretty => write!(f, "json (pretty)"),
+        }
+    }
+}
+
 pub struct Settings {
     #[cfg(feature = "color")]
     pub color: bool,
     pub format: Format,
-    pub maps: bool,
     pub libraries: bool,
 }
 
 impl Settings {
     #[must_use]
     #[cfg(feature = "color")]
-    pub fn set(
-        color: bool,
-        format: Format,
-        maps: bool,
-        libraries: bool,
-    ) -> Self {
+    pub fn set(color: bool, format: Format, libraries: bool) -> Self {
         if color {
             // honor NO_COLOR if it is set within the environment
             if env::var("NO_COLOR").is_ok() {
-                return Self { color: false, format, maps, libraries };
+                return Self { color: false, format, libraries };
             }
         } else {
             control::set_override(false);
         }
-        Self { color, format, maps, libraries }
+        Self { color, format, libraries }
     }
     #[must_use]
     #[cfg(not(feature = "color"))]
-    pub fn set(format: Format, maps: bool, libraries: bool) -> Self {
-        Self { format, maps, libraries }
+    pub fn set(format: Format, libraries: bool) -> Self {
+        Self { format, libraries }
     }
 }


### PR DESCRIPTION
Use subcommand instead of option arguments. This has the benefit of supporting shell wildcards.

Old usage:

    checksec -f /bin/true --no-color
    checksec -d /bin --json --pretty
    checksec -p bash --maps
    checksec --pid 1,42
    checksec -P

New usage:

    checksec --no-color exe /bin/true
    checksec --format json-pretty exe /bin
    checksec proc-name --maps bash
    checksec proc-id 1 42
    checksec proc-all

    checksec proc-id $(pidof firefox)
    checksec exe /bin/system*
    dpkg -L apt | checksec

Alternative to #25