### PR TITLE
Update to goblin 0.6.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -190,9 +190,9 @@ dependencies = [
 
 [[package]]
 name = "goblin"
-version = "0.5.4"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7666983ed0dd8d21a6f6576ee00053ca0926fb281a5522577a4dbd0f1b54143"
+checksum = "572564d6cba7d09775202c8e7eebc4d534d5ae36578ab402fb21e182a0ac9505"
 dependencies = [
  "log",
  "plain",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ panic = 'abort'   # Abort on panic
 clap = {version = "4.0.14", features = ["cargo"]}
 colored = {version = "2.0.0", optional = true}
 colored_json = {version = "3.0.1", optional = true}
-goblin = "0.5.4"
+goblin = "0.6.0"
 ignore = "0.4.18"
 memmap2 = "0.5.7"
 scroll = "0.11.0"

--- a/examples/macho_print_checksec_results.rs
+++ b/examples/macho_print_checksec_results.rs
@@ -2,7 +2,10 @@ extern crate checksec;
 extern crate goblin;
 
 use checksec::macho::CheckSecResults;
-use goblin::mach::{Mach, MachO};
+use goblin::mach::cputype::get_arch_name_from_types;
+use goblin::mach::Mach;
+use goblin::mach::SingleArch::Archive;
+use goblin::mach::SingleArch::MachO;
 use goblin::Object;
 use std::{env, fs};
 
@@ -12,32 +15,60 @@ fn main() {
         2 => {
             if fs::File::open(&argv[1]).is_ok() {
                 if let Ok(buf) = fs::read(&argv[1]) {
-                    match Object::parse(&buf).unwrap() {
-                        Object::Mach(mach) => match mach {
-                            Mach::Binary(macho) => {
-                                println!(
-                                    "{:#?}",
-                                    CheckSecResults::parse(&macho)
-                                );
-                            }
-                            Mach::Fat(fatmach) => {
-                                for (idx, _) in
-                                    fatmach.iter_arches().enumerate()
-                                {
-                                    let container: MachO =
-                                        fatmach.get(idx).unwrap();
-                                    println!(
-                                        "{:#?}",
-                                        CheckSecResults::parse(&container)
-                                    );
-                                }
-                            }
-                        },
-                        _ => eprintln!("not a mach binary"),
-                    }
+                    parse(&buf);
                 }
             }
         }
         _ => eprintln!("Usage: macho_print_checksec_results <binary>"),
+    }
+}
+
+fn parse(bytes: &[u8]) {
+    match Object::parse(&bytes).unwrap() {
+        Object::Mach(mach) => match mach {
+            Mach::Binary(macho) => {
+                println!("{:#?}", CheckSecResults::parse(&macho));
+            }
+            Mach::Fat(fatmach) => {
+                for (idx, fatarch) in fatmach.iter_arches().enumerate() {
+                    match fatmach.get(idx).unwrap() {
+                        MachO(mach) => {
+                            let machine = get_arch_name_from_types(
+                                mach.header.cputype(),
+                                mach.header.cpusubtype(),
+                            )
+                            .unwrap_or("UNKNOWN");
+                            println!("# Machine type {}:", machine);
+                            println!("{:#?}", CheckSecResults::parse(&mach))
+                        }
+                        Archive(archive) => {
+                            let fatarch = fatarch.unwrap();
+
+                            let archive_bytes = &bytes[fatarch.offset as usize
+                                ..(fatarch.offset + fatarch.size) as usize];
+
+                            for member in archive.members() {
+                                match archive.extract(member, archive_bytes) {
+                                    Ok(ext_bytes) => {
+                                        println!(
+                                            "# Archive member {}:",
+                                            member
+                                        );
+                                        parse(ext_bytes);
+                                    }
+                                    Err(err) => {
+                                        eprintln!(
+                                            "Failed to extract member {}: {}",
+                                            member, err
+                                        );
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        _ => eprintln!("not a mach binary"),
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -12,7 +12,7 @@ use clap::{
 };
 use goblin::error::Error;
 #[cfg(feature = "macho")]
-use goblin::mach::Mach;
+use goblin::mach::{Mach, SingleArch::Archive, SingleArch::MachO};
 use goblin::Object;
 use ignore::Walk;
 use memmap2::Mmap;
@@ -191,78 +191,106 @@ fn parse_bytes(bytes: &[u8], file: &Path) -> Result<Vec<Binary>, ParseError> {
             )])
         }
         #[cfg(feature = "macho")]
-        Object::Mach(mach) => match mach {
-            Mach::Binary(macho) => {
-                let results = macho::CheckSecResults::parse(&macho);
-                let bin_type = if macho.is_64 {
-                    BinType::MachO64
-                } else {
-                    BinType::MachO32
-                };
-                Ok(vec![Binary::new(
-                    bin_type,
-                    file.to_path_buf(),
-                    BinSpecificProperties::MachO(results),
-                )])
-            }
-            Mach::Fat(fatmach) => {
-                let mut fat_bins: Vec<Binary> = Vec::new();
-                for (idx, _) in fatmach.arches()?.iter().enumerate() {
-                    if let Ok(container) = fatmach.get(idx) {
-                        let results =
-                            macho::CheckSecResults::parse(&container);
-                        let bin_type = if container.is_64 {
-                            BinType::MachO64
-                        } else {
-                            BinType::MachO32
-                        };
-                        fat_bins.push(Binary::new(
-                            bin_type,
-                            file.to_path_buf(),
-                            BinSpecificProperties::MachO(results),
-                        ));
-                    }
+        Object::Mach(mach) => {
+            match mach {
+                Mach::Binary(macho) => {
+                    let results = macho::CheckSecResults::parse(&macho);
+                    let bin_type = if macho.is_64 {
+                        BinType::MachO64
+                    } else {
+                        BinType::MachO32
+                    };
+                    Ok(vec![Binary::new(
+                        bin_type,
+                        file.to_path_buf(),
+                        BinSpecificProperties::MachO(results),
+                    )])
                 }
-                Ok(fat_bins)
+                Mach::Fat(fatmach) => {
+                    let mut fat_bins: Vec<Binary> = Vec::new();
+                    for (idx, fatarch) in fatmach.iter_arches().enumerate() {
+                        if let Ok(container) = fatmach.get(idx) {
+                            match container {
+                                MachO(mach) => {
+                                    let results =
+                                        macho::CheckSecResults::parse(&mach);
+                                    let bin_type = if mach.is_64 {
+                                        BinType::MachO64
+                                    } else {
+                                        BinType::MachO32
+                                    };
+                                    fat_bins.push(Binary::new(
+                                        bin_type,
+                                        file.to_path_buf(),
+                                        BinSpecificProperties::MachO(results),
+                                    ));
+                                }
+                                Archive(archive) => {
+                                    let fatarch = fatarch?;
+                                    if let Some(archive_bytes) = bytes.get(
+                                        fatarch.offset as usize
+                                            ..(fatarch.offset + fatarch.size)
+                                                as usize,
+                                    ) {
+                                        fat_bins.append(&mut parse_archive(
+                                            &archive,
+                                            file,
+                                            archive_bytes,
+                                        ));
+                                    } else {
+                                        Err(goblin::error::Error::Malformed("Archive refers to invalid position".to_string()))?;
+                                    }
+                                }
+                            }
+                        }
+                    }
+                    Ok(fat_bins)
+                }
             }
-        },
+        }
         #[cfg(not(feature = "elf"))]
         Object::Elf(_) => Err(ParseError::Unimplemented("ELF")),
         #[cfg(not(feature = "pe"))]
         Object::PE(_) => Err(ParseError::Unimplemented("PE")),
         #[cfg(not(feature = "macho"))]
         Object::Mach(_) => Err(ParseError::Unimplemented("MachO")),
-        Object::Archive(archive) => Ok(archive
-            .members()
-            .iter()
-            .filter_map(|member_name| {
-                match archive.extract(member_name, bytes) {
-                    Ok(ext_bytes) => parse_bytes(
-                        ext_bytes,
-                        Path::new(&format!(
-                            "{}\u{2794}{}",
-                            file.display(),
-                            member_name
-                        )),
-                    )
-                    .ok(),
-                    Err(err) => {
-                        eprintln!(
-                            "Failed to extract member {} of {}: {}",
-                            member_name,
-                            file.display(),
-                            err
-                        );
-                        None
-                    }
-                }
-            })
-            .flatten()
-            .collect()),
+        Object::Archive(archive) => Ok(parse_archive(&archive, file, bytes)),
         Object::Unknown(magic) => {
             Err(ParseError::Goblin(Error::BadMagic(magic)))
         }
     }
+}
+
+fn parse_archive(
+    archive: &goblin::archive::Archive,
+    file: &Path,
+    bytes: &[u8],
+) -> Vec<Binary> {
+    archive
+        .members()
+        .iter()
+        .filter_map(|member_name| match archive.extract(member_name, bytes) {
+            Ok(ext_bytes) => parse_bytes(
+                ext_bytes,
+                Path::new(&format!(
+                    "{}\u{2794}{}",
+                    file.display(),
+                    member_name
+                )),
+            )
+            .ok(),
+            Err(err) => {
+                eprintln!(
+                    "Failed to extract member {} of {}: {}",
+                    member_name,
+                    file.display(),
+                    err
+                );
+                None
+            }
+        })
+        .flatten()
+        .collect()
 }
 
 fn walk(basepath: &Path, settings: &output::Settings) {


### PR DESCRIPTION
Goblin added support for archives in Mach fat binaries, see https://github.com/m4b/goblin/commit/e2b5207a0d2dd4e8cc9111be1c1fb0a129c51632.

Tested against the binaries from that commit.