### PR TITLE
UNIX: highlight files with elevated permissions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -66,6 +66,7 @@ dependencies = [
  "serde_json",
  "sysinfo",
  "windows",
+ "xattr",
 ]
 
 [[package]]
@@ -599,6 +600,15 @@ name = "windows_x86_64_msvc"
 version = "0.42.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f40009d85759725a34da6d89a94e63d7bdc50a862acf0dbc7c8e488f1edcb6f5"
+
+[[package]]
+name = "xattr"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea263437ca03c1522846a4ddafbca2542d0ad5ed9b784909d4b27b76f62bc34a"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "yansi"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,6 +49,9 @@ windows = {version = "0.42.0", features = [
   "Win32_System_Threading",
 ]}
 
+[target.'cfg(target_os="linux")'.dependencies]
+xattr = {version = "1.0.0", optional = true}
+
 [lib]
 name = "checksec"
 path = "src/lib.rs"
@@ -58,7 +61,7 @@ name = "checksec"
 path = "src/main.rs"
 
 [features]
-color = ["colored", "colored_json"]
+color = ["colored", "colored_json", "xattr"]
 default = ["elf", "macho", "pe", "color", "maps"]
 elf = ["shared"]
 macho = ["shared"]


### PR DESCRIPTION
Highlight the filenames of files with SETUID or SETGID flags set. Also highlight files with file capabilities.