### PR TITLE
examples: please clippy

### DIFF
--- a/examples/macho_print_checksec_results.rs
+++ b/examples/macho_print_checksec_results.rs
@@ -24,7 +24,7 @@ fn main() {
 }
 
 fn parse(bytes: &[u8]) {
-    match Object::parse(&bytes).unwrap() {
+    match Object::parse(bytes).unwrap() {
         Object::Mach(mach) => match mach {
             Mach::Binary(macho) => {
                 println!("{:#?}", CheckSecResults::parse(&macho));


### PR DESCRIPTION
    warning: this expression creates a reference which is immediately dereferenced by the compiler
      --> examples/macho_print_checksec_results.rs:27:25
       |
    27 |     match Object::parse(&bytes).unwrap() {
       |                         ^^^^^^ help: change this to: `bytes`
       |