### PR TITLE
Adds checks for IntelCET Indirect Branch Tracking (IBT) and Shadow Stack (SHSTK)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ colored = {version = "2.0.0", optional = true}
 colored_json = {version = "3.0.1", optional = true}
 either = "1.8.1"
 glob = "0.3.0"
-goblin = "0.6.0"
+goblin = "0.7.1"
 iced-x86 = {version = "1.18.0", optional = true}
 ignore = "0.4.18"
 itertools = "0.10.5"


### PR DESCRIPTION
Checks the `.note.gnu.property` section of an ELF file for the properties GNU_PROPERTY_X86_FEATURE_1_IBT (Indirect branch tracking) and GNU_PROPERTY_X86_FEATURE_1_SHSTK (Shadow Stack)

These are features from the Intel Control-flow Enforcement Technology (IntelCET) [(Architectures Software
Developer’s Manual Volume 1 - Chapter 17)](https://www.intel.com/content/www/us/en/developer/articles/technical/intel-sdm.html), which will provide hardware supported control flow checks in the future. This is intended to protect against such threats as Return-oriented Programming (ROP), and similarly call/jmp-oriented programming (COP/JOP). Unlike software solutions, this also works during Spectre-like attacks. While the ShadowStack ist already supported by multiple CPUs by both Intel and AMD, IBT is only supported by Intel Tiger Lake as of now. However, GCC is in the process of introducing a new -fhardened [[1]](https://gcc.gnu.org/pipermail/gcc-patches/2023-September/630550.html) [[2]](https://www.phoronix.com/news/GCC-fhardened-Hardening-Option) flag, which includes this feature. Thus, i value this to be a relevant feature to check for.

IBT and SHSTK can be enabled during compilation with the following flags:
`*CFLAGS=*-fcf-protection=[full|branch|return|none]` [link](https://gcc.gnu.org/onlinedocs/gcc/Instrumentation-Options.html#index-fcf-protection)

Notes:
- The Notes section in the elf file could lie and report enabled IBT while no endbr32/64 instruction have been actually introduced.
- The current Goblin 0.6.0 is missing the `NT_GNU_PROPERTY_TYPE_0` constant for this. I set the Goblin version to the latest current version of 0.7.1. However, 0.6.1 would be sufficient for this patch to work if you don't want Goblin 0.7.x.
- EDIT: Current Implementation will (probably) only work for little endian elf files

~~Future Work:
While Windows does not make use of the Indirect branch tracking feature, you can enable the shadow stack [link](https://learn.microsoft.com/de-de/cpp/build/reference/cetcompat?view=msvc-170). Thus, PE files should/could also be checked for this.~~ EDIT: Done