### PR TITLE
Fixes for MachO: @rpath TODO, Issue #44, Issue #6

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,7 +141,6 @@ See [examples/](https://github.com/etke/checksec.rs/tree/master/examples) for li
     * Rpath RW
 * Platform independent checks
   * MachO
-    * `@rpath` contents into `shared::VecRpath` similar to `DT_RPATH`/`DT_RUNPATH` on ELFs
     * Code signature validation
 
 ### checksec todos

--- a/src/macho.rs
+++ b/src/macho.rs
@@ -150,9 +150,9 @@ impl fmt::Display for CheckSecResults {
 /// }
 /// ```
 pub trait Properties {
-    /// check import names for `_objc_release`
+    /// check symbol names for `_objc_release` or `_swift_release`
     fn has_arc(&self) -> bool;
-    /// check import names for `___stack_chk_fail` or `___stack_chk_guard`
+    /// check symbol names for `___stack_chk_fail` `___stack_chk_guard` or `___chkstk_darwin`
     fn has_canary(&self) -> bool;
     /// check data size of code signature in load commands
     fn has_code_signature(&self) -> bool;
@@ -178,8 +178,9 @@ impl Properties for MachO<'_> {
     fn has_arc(&self) -> bool {
         for i in self.symbols() {
             if let Ok((symbol,_)) = i {
-                if symbol == "_objc_release" {
-                    return true;
+                match symbol {
+                    "_objc_release" | "_swift_release" => return true,
+                    _ => continue,
                 }
             }
         }
@@ -189,7 +190,7 @@ impl Properties for MachO<'_> {
         for i in self.symbols() {
             if let Ok((symbol,_)) = i {
                 match symbol {
-                    "___stack_chk_fail" | "___stack_chk_guard" => return true,
+                    "___stack_chk_fail" | "___stack_chk_guard" | "___chkstk_darwin" => return true,
                     _ => continue,
                 }
             }

--- a/src/macho.rs
+++ b/src/macho.rs
@@ -176,9 +176,9 @@ pub trait Properties {
 }
 impl Properties for MachO<'_> {
     fn has_arc(&self) -> bool {
-        if let Ok(imports) = self.imports() {
-            for import in &imports {
-                if import.name == "_objc_release" {
+        for i in self.symbols() {
+            if let Ok((symbol,_)) = i {
+                if symbol == "_objc_release" {
                     return true;
                 }
             }
@@ -186,9 +186,9 @@ impl Properties for MachO<'_> {
         false
     }
     fn has_canary(&self) -> bool {
-        if let Ok(imports) = self.imports() {
-            for import in &imports {
-                match import.name {
+        for i in self.symbols() {
+            if let Ok((symbol,_)) = i {
+                match symbol {
                     "___stack_chk_fail" | "___stack_chk_guard" => return true,
                     _ => continue,
                 }


### PR DESCRIPTION
Completes this TODO from the README.md:
`@rpath` contents into `shared::VecRpath` similar to `DT_RPATH`/`DT_RUNPATH` on ELFs

The whole @rpath is now displayed similar to the RPATH and RUNPATH for ELFs, when one is found.

EDIT: Fixes #44 and #6 aswell now.